### PR TITLE
add engine SDK

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("jvm")
+    `maven-publish`
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+    maven("https://dl.bintray.com/kotlin/kotlinx")
+}
+
+val jar by tasks.getting(Jar::class) {
+    archiveBaseName.set("engine-sdk")
+}
+
+dependencies {
+    compile(kotlin("stdlib"))
+    compile(kotlin("reflect"))
+    compile("org.json:json:20190722")
+    compile("com.squareup.okhttp3:okhttp:4.2.2")
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/Delphix.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/Delphix.kt
@@ -25,9 +25,9 @@ import com.delphix.sdk.repos.SourceConfig
 import com.delphix.sdk.repos.SourceEnvironment
 import com.delphix.sdk.repos.TimeflowSnapshot
 
-open class Delphix (
+open class Delphix(
     var http: Http
-){
+) {
     val loginResource: String = "/resources/json/delphix/login"
 
     fun requestLogin(username: String, password: String): Map<String, String> {
@@ -52,11 +52,11 @@ open class Delphix (
     }
 
     fun group(): Group {
-      return Group(http)
+        return Group(http)
     }
 
     fun repository(): Repository {
-      return Repository(http)
+        return Repository(http)
     }
 
     fun source(): Source {

--- a/engine/src/main/kotlin/com/delphix/sdk/Delphix.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/Delphix.kt
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.delphix.sdk
+
+import com.delphix.sdk.repos.Action
+import com.delphix.sdk.repos.Container
+import com.delphix.sdk.repos.EnvironmentUser
+import com.delphix.sdk.repos.Group
+import com.delphix.sdk.repos.Host
+import com.delphix.sdk.repos.Job
+import com.delphix.sdk.repos.Repository
+import com.delphix.sdk.repos.Source
+import com.delphix.sdk.repos.SourceConfig
+import com.delphix.sdk.repos.SourceEnvironment
+import com.delphix.sdk.repos.TimeflowSnapshot
+
+open class Delphix (
+    var http: Http
+){
+    val loginResource: String = "/resources/json/delphix/login"
+
+    fun requestLogin(username: String, password: String): Map<String, String> {
+        return mapOf("type" to "LoginRequest", "username" to username, "password" to password)
+    }
+
+    open fun login(username: String, password: String) {
+        http.setSession()
+        http.handlePost(loginResource, requestLogin(username, password))
+    }
+
+    fun action(): Action {
+        return Action(http)
+    }
+
+    fun job(): Job {
+        return Job(http)
+    }
+
+    fun container(): Container {
+        return Container(http)
+    }
+
+    fun group(): Group {
+      return Group(http)
+    }
+
+    fun repository(): Repository {
+      return Repository(http)
+    }
+
+    fun source(): Source {
+        return Source(http)
+    }
+
+    fun sourceConfig(): SourceConfig {
+        return SourceConfig(http)
+    }
+
+    fun sourceEnvironment(): SourceEnvironment {
+        return SourceEnvironment(http)
+    }
+
+    fun snapshot(): TimeflowSnapshot {
+        return TimeflowSnapshot(http)
+    }
+
+    fun host(): Host {
+        return Host(http)
+    }
+
+    fun environmentUser(): EnvironmentUser {
+        return EnvironmentUser(http)
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/Http.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/Http.kt
@@ -4,22 +4,25 @@
 
 package com.delphix.sdk
 
-import okhttp3.*
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.json.JSONObject
 import java.io.IOException
 import java.util.concurrent.TimeUnit
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody
+import org.json.JSONObject
 
 class Http(
-        val engineAddress: String,
-        private val debug: Boolean = false,
-        private val versionMajor: Int = 1,
-        private val versionMinor: Int = 7,
-        private val versionMicro: Int = 0,
-        private val timeout: Long = 60,
-        private val timeoutUnit: TimeUnit = TimeUnit.MINUTES
-){
+    val engineAddress: String,
+    private val debug: Boolean = false,
+    private val versionMajor: Int = 1,
+    private val versionMinor: Int = 7,
+    private val versionMicro: Int = 0,
+    private val timeout: Long = 60,
+    private val timeoutUnit: TimeUnit = TimeUnit.MINUTES
+) {
     private val sessionResource: String = "/resources/json/delphix/session"
     private var JSESSIONID: String = ""
 
@@ -76,7 +79,7 @@ class Http(
         if (debug) println(url)
         val request = Request.Builder()
                 .url("$engineAddress$url")
-                .addHeader("Cookie","JSESSIONID=$JSESSIONID")
+                .addHeader("Cookie", "JSESSIONID=$JSESSIONID")
                 .build()
         val response = call(request).asJsonObject()
         validateResponse(response)
@@ -89,7 +92,7 @@ class Http(
         val requestBody = JSONObject(data).toString().toRequestBody(json)
         val request = Request.Builder()
                 .url("$engineAddress$url")
-                .addHeader("Cookie","JSESSIONID=$JSESSIONID")
+                .addHeader("Cookie", "JSESSIONID=$JSESSIONID")
                 .post(requestBody)
                 .build()
         val response = call(request).asJsonObject()
@@ -97,11 +100,11 @@ class Http(
         return response
     }
 
-    fun handleDelete(url:String): JSONObject {
+    fun handleDelete(url: String): JSONObject {
         if (debug) println(url)
         val request = Request.Builder()
                 .url("$engineAddress$url")
-                .addHeader("Cookie","JSESSIONID=$JSESSIONID")
+                .addHeader("Cookie", "JSESSIONID=$JSESSIONID")
                 .delete()
                 .build()
         val response = call(request).asJsonObject()

--- a/engine/src/main/kotlin/com/delphix/sdk/Http.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/Http.kt
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk
+
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+class Http(
+        val engineAddress: String,
+        private val debug: Boolean = false,
+        private val versionMajor: Int = 1,
+        private val versionMinor: Int = 7,
+        private val versionMicro: Int = 0,
+        private val timeout: Long = 60,
+        private val timeoutUnit: TimeUnit = TimeUnit.MINUTES
+){
+    private val sessionResource: String = "/resources/json/delphix/session"
+    private var JSESSIONID: String = ""
+
+    private fun call(request: Request): ResponseBody {
+        val caller = OkHttpClient.Builder()
+                .readTimeout(timeout, timeoutUnit)
+                .build()
+        val response = caller.newCall(request).execute()
+        if (!response.isSuccessful) {
+            throw IOException("Unexpected Code: $response")
+        }
+        checkCookie(response)
+        return response.body!!
+    }
+
+    private fun validateResponse(response: JSONObject) {
+        if (debug) println(response)
+        if (response.get("status") == "ERROR") {
+            val error = response.getJSONObject("error")
+            val details = error.get("details")
+            val action = error.get("action")
+            throw Exception("$details $action")
+        }
+    }
+
+    private fun requestSessions(): Map<String, Any> {
+        val version = mapOf("type" to "APIVersion", "major" to versionMajor, "minor" to versionMinor, "micro" to versionMicro)
+        return mapOf("type" to "APISession", "version" to version)
+    }
+
+    private fun checkCookie(r: Response) {
+        val cookieDough = r.header("Set-Cookie")
+        if (!cookieDough.isNullOrEmpty()) {
+            val cookies = cookieDough.split(";")
+            JSESSIONID = cookies[0].split("=")[1]
+        }
+    }
+
+    fun setSession() {
+        val json = "application/json; charset=utf-8".toMediaTypeOrNull()
+        val requestBody = JSONObject(requestSessions()).toString().toRequestBody(json)
+        val request = Request.Builder()
+                .url("$engineAddress$sessionResource")
+                .post(requestBody)
+                .build()
+        val caller = OkHttpClient.Builder()
+                .readTimeout(timeout, timeoutUnit)
+                .build()
+        val response = caller.newCall(request).execute()
+        checkCookie(response)
+    }
+
+    fun handleGet(url: String): JSONObject {
+        if (debug) println(url)
+        val request = Request.Builder()
+                .url("$engineAddress$url")
+                .addHeader("Cookie","JSESSIONID=$JSESSIONID")
+                .build()
+        val response = call(request).asJsonObject()
+        validateResponse(response)
+        return response
+    }
+
+    fun handlePost(url: String, data: Map<String, Any?>): JSONObject {
+        if (debug) println(url)
+        val json = "application/json; charset=utf-8".toMediaTypeOrNull()
+        val requestBody = JSONObject(data).toString().toRequestBody(json)
+        val request = Request.Builder()
+                .url("$engineAddress$url")
+                .addHeader("Cookie","JSESSIONID=$JSESSIONID")
+                .post(requestBody)
+                .build()
+        val response = call(request).asJsonObject()
+        validateResponse(response)
+        return response
+    }
+
+    fun handleDelete(url:String): JSONObject {
+        if (debug) println(url)
+        val request = Request.Builder()
+                .url("$engineAddress$url")
+                .addHeader("Cookie","JSESSIONID=$JSESSIONID")
+                .delete()
+                .build()
+        val response = call(request).asJsonObject()
+        validateResponse(response)
+        return response
+    }
+
+    companion object {
+        fun ResponseBody.asString(): String {
+            return this.string()
+        }
+        fun ResponseBody.asJsonObject(): JSONObject {
+            return JSONObject(this.asString())
+        }
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/APIError.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/APIError.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * Description of an error encountered during an API call.
  */
-open class APIError (
-    open val commandOutput: String? = null,//Extra output, often from a script or other external process, that may give more insight into the cause of this error.
-    open val action: String? = null,//Action to be taken by the user, if any, to fix the underlying problem.
-    open val details: Any? = null,//For validation errors, a map of fields to APIError objects. For all other errors, a string with further details of the error.
-    open val id: String? = null,//A stable identifier for the class of error encountered.
-    open val diagnoses: List<DiagnosisResult>,//Results of diagnostic checks run, if any, if the job failed.
+open class APIError(
+    open val commandOutput: String? = null, // Extra output, often from a script or other external process, that may give more insight into the cause of this error.
+    open val action: String? = null, // Action to be taken by the user, if any, to fix the underlying problem.
+    open val details: Any? = null, // For validation errors, a map of fields to APIError objects. For all other errors, a string with further details of the error.
+    open val id: String? = null, // A stable identifier for the class of error encountered.
+    open val diagnoses: List<DiagnosisResult>, // Results of diagnostic checks run, if any, if the job failed.
     override val type: String = "APIError"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -25,4 +25,3 @@ open class APIError (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/APIError.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/APIError.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Description of an error encountered during an API call.
+ */
+open class APIError (
+    open val commandOutput: String? = null,//Extra output, often from a script or other external process, that may give more insight into the cause of this error.
+    open val action: String? = null,//Action to be taken by the user, if any, to fix the underlying problem.
+    open val details: Any? = null,//For validation errors, a map of fields to APIError objects. For all other errors, a string with further details of the error.
+    open val id: String? = null,//A stable identifier for the class of error encountered.
+    open val diagnoses: List<DiagnosisResult>,//Results of diagnostic checks run, if any, if the job failed.
+    override val type: String = "APIError"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "commandOutput" to commandOutput,
+            "action" to action,
+            "details" to details,
+            "id" to id,
+            "diagnoses" to diagnoses,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/APISession.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/APISession.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Describes a Delphix web service session and is the result of an initial handshake.
+ */
+open class APISession (
+    open val client: String? = null,//Client software identification token.
+    open val locale: String? = null,//Locale as an IETF BCP 47 language tag, defaults to 'en-US'.
+    open val version: APIVersion? = null,//Version of the API to use.
+    override val type: String = "APISession"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "client" to client,
+            "locale" to locale,
+            "version" to version,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/APISession.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/APISession.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * Describes a Delphix web service session and is the result of an initial handshake.
  */
-open class APISession (
-    open val client: String? = null,//Client software identification token.
-    open val locale: String? = null,//Locale as an IETF BCP 47 language tag, defaults to 'en-US'.
-    open val version: APIVersion? = null,//Version of the API to use.
+open class APISession(
+    open val client: String? = null, // Client software identification token.
+    open val locale: String? = null, // Locale as an IETF BCP 47 language tag, defaults to 'en-US'.
+    open val version: APIVersion? = null, // Version of the API to use.
     override val type: String = "APISession"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class APISession (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/APIVersion.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/APIVersion.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * Describes an API version.
  */
-open class APIVersion (
-    open val major: Int? = null,//Major API version number.
-    open val minor: Int? = null,//Minor API version number.
-    open val micro: Int? = null,//Micro API version number.
+open class APIVersion(
+    open val major: Int? = null, // Major API version number.
+    open val minor: Int? = null, // Minor API version number.
+    open val micro: Int? = null, // Micro API version number.
     override val type: String = "APIVersion"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class APIVersion (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/APIVersion.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/APIVersion.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Describes an API version.
+ */
+open class APIVersion (
+    open val major: Int? = null,//Major API version number.
+    open val minor: Int? = null,//Minor API version number.
+    open val micro: Int? = null,//Micro API version number.
+    override val type: String = "APIVersion"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "major" to major,
+            "minor" to minor,
+            "micro" to micro,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Action.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Action.kt
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Represents an action, a permanent record of activity on the server.
+ */
+open class Action (
+    open val failureAction: String? = null,//Action to be taken to resolve the failure.
+    open val workSource: String? = null,//Origin of the work that caused the action.
+    open val userAgent: String? = null,//Name of client software used to initiate the action.
+    open val title: String? = null,//Action title.
+    open val failureMessageCode: String? = null,//Message ID associated with the event.
+    open val actionType: String? = null,//Action type.
+    open val report: String? = null,//Report of progress and warnings for some actions.
+    open val details: String? = null,//Plain text description of the action.
+    open val startTime: String? = null,//The time the action occurred. For long running processes, this represents the starting time.
+    open val endTime: String? = null,//The time the action completed.
+    open val state: String? = null,//State of the action.
+    open val parentAction: String? = null,//The parent action of this action.
+    open val user: String? = null,//User who initiated the action.
+    open val workSourceName: String? = null,//Name of user or policy that initiated the action.
+    open val failureDescription: String? = null,//Details of the action failure.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "Action"
+) : PersistentObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "failureAction" to failureAction,
+            "workSource" to workSource,
+            "userAgent" to userAgent,
+            "title" to title,
+            "failureMessageCode" to failureMessageCode,
+            "actionType" to actionType,
+            "report" to report,
+            "details" to details,
+            "startTime" to startTime,
+            "endTime" to endTime,
+            "state" to state,
+            "parentAction" to parentAction,
+            "user" to user,
+            "workSourceName" to workSourceName,
+            "failureDescription" to failureDescription,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Action.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Action.kt
@@ -6,24 +6,24 @@ package com.delphix.sdk.objects
 /**
  * Represents an action, a permanent record of activity on the server.
  */
-open class Action (
-    open val failureAction: String? = null,//Action to be taken to resolve the failure.
-    open val workSource: String? = null,//Origin of the work that caused the action.
-    open val userAgent: String? = null,//Name of client software used to initiate the action.
-    open val title: String? = null,//Action title.
-    open val failureMessageCode: String? = null,//Message ID associated with the event.
-    open val actionType: String? = null,//Action type.
-    open val report: String? = null,//Report of progress and warnings for some actions.
-    open val details: String? = null,//Plain text description of the action.
-    open val startTime: String? = null,//The time the action occurred. For long running processes, this represents the starting time.
-    open val endTime: String? = null,//The time the action completed.
-    open val state: String? = null,//State of the action.
-    open val parentAction: String? = null,//The parent action of this action.
-    open val user: String? = null,//User who initiated the action.
-    open val workSourceName: String? = null,//Name of user or policy that initiated the action.
-    open val failureDescription: String? = null,//Details of the action failure.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class Action(
+    open val failureAction: String? = null, // Action to be taken to resolve the failure.
+    open val workSource: String? = null, // Origin of the work that caused the action.
+    open val userAgent: String? = null, // Name of client software used to initiate the action.
+    open val title: String? = null, // Action title.
+    open val failureMessageCode: String? = null, // Message ID associated with the event.
+    open val actionType: String? = null, // Action type.
+    open val report: String? = null, // Report of progress and warnings for some actions.
+    open val details: String? = null, // Plain text description of the action.
+    open val startTime: String? = null, // The time the action occurred. For long running processes, this represents the starting time.
+    open val endTime: String? = null, // The time the action completed.
+    open val state: String? = null, // State of the action.
+    open val parentAction: String? = null, // The parent action of this action.
+    open val user: String? = null, // User who initiated the action.
+    open val workSourceName: String? = null, // Name of user or policy that initiated the action.
+    open val failureDescription: String? = null, // Details of the action failure.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "Action"
 ) : PersistentObject {
     override fun toMap(): Map<String, Any?> {
@@ -49,4 +49,3 @@ open class Action (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataAdditionalMountPoint.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataAdditionalMountPoint.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Specifies an additional location on which to mount a subdirectory of an AppData container.
+ */
+open class AppDataAdditionalMountPoint (
+    open val environment: String? = null,//Reference to the environment on which the file system will be mounted.
+    open val mountPath: String? = null,//Absolute path on the target environment were the filesystem should be mounted.
+    open val sharedPath: String? = null,//Relative path within the container of the directory that should be mounted.
+    override val type: String = "AppDataAdditionalMountPoint"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "environment" to environment,
+            "mountPath" to mountPath,
+            "sharedPath" to sharedPath,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataAdditionalMountPoint.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataAdditionalMountPoint.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * Specifies an additional location on which to mount a subdirectory of an AppData container.
  */
-open class AppDataAdditionalMountPoint (
-    open val environment: String? = null,//Reference to the environment on which the file system will be mounted.
-    open val mountPath: String? = null,//Absolute path on the target environment were the filesystem should be mounted.
-    open val sharedPath: String? = null,//Relative path within the container of the directory that should be mounted.
+open class AppDataAdditionalMountPoint(
+    open val environment: String? = null, // Reference to the environment on which the file system will be mounted.
+    open val mountPath: String? = null, // Absolute path on the target environment were the filesystem should be mounted.
+    open val sharedPath: String? = null, // Relative path within the container of the directory that should be mounted.
     override val type: String = "AppDataAdditionalMountPoint"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class AppDataAdditionalMountPoint (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataBaseTimeflow.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataBaseTimeflow.kt
@@ -7,13 +7,13 @@ package com.delphix.sdk.objects
  * TimeFlow representing historical data for a particular timeline within a data container.
  */
 interface AppDataBaseTimeflow : Timeflow {
-    override val parentPoint: TimeflowPoint?//The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
-    override val container: String?//Reference to the data container (database) for this TimeFlow.
-    override val creationType: String?//The source action that created the TimeFlow.
-    override val parentSnapshot: String?//Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val parentPoint: TimeflowPoint? // The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
+    override val container: String? // Reference to the data container (database) for this TimeFlow.
+    override val creationType: String? // The source action that created the TimeFlow.
+    override val parentSnapshot: String? // Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataBaseTimeflow.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataBaseTimeflow.kt
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow representing historical data for a particular timeline within a data container.
+ */
+interface AppDataBaseTimeflow : Timeflow {
+    override val parentPoint: TimeflowPoint?//The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
+    override val container: String?//Reference to the data container (database) for this TimeFlow.
+    override val creationType: String?//The source action that created the TimeFlow.
+    override val parentSnapshot: String?//Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainer.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainer.kt
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Data container for AppData.
+ */
+open class AppDataContainer (
+    override val group: String? = null,//A reference to the group containing this container.
+    override val name: String? = null,//Object name.
+    open val toolkit: String? = null,//The toolkit managing the data in the container.
+    override val runtime: DBContainerRuntime? = null,//Runtime properties of this container.
+    override val restoration: Boolean? = null,//True if this container is part of a restoration dataset.
+    override val os: String? = null,//Native operating system of the original database source system.
+    override val performanceMode: String? = null,//Whether to enable high performance mode.
+    override val processor: String? = null,//Native processor type of the original database source system.
+    override val sourcingPolicy: SourcingPolicy? = null,//Policies for managing LogSync and SnapSync across sources.
+    override val currentTimeflow: String? = null,//A reference to the currently active TimeFlow for this container.
+    override val previousTimeflow: String? = null,//A reference to the previous TimeFlow for this container.
+    override val creationTime: String? = null,//The date this container was created.
+    override val masked: Boolean? = null,//True if this container is a masked container.
+    override val description: String? = null,//Optional user-provided description for the container.
+    override val provisionContainer: String? = null,//A reference to the container this container was provisioned from.
+    override val transformation: Boolean? = null,//True if this container is a transformation container.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "AppDataContainer"
+) : DatabaseContainer {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "toolkit" to toolkit,
+            "runtime" to runtime,
+            "restoration" to restoration,
+            "os" to os,
+            "performanceMode" to performanceMode,
+            "processor" to processor,
+            "sourcingPolicy" to sourcingPolicy,
+            "currentTimeflow" to currentTimeflow,
+            "previousTimeflow" to previousTimeflow,
+            "creationTime" to creationTime,
+            "masked" to masked,
+            "description" to description,
+            "provisionContainer" to provisionContainer,
+            "transformation" to transformation,
+            "group" to group,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainer.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainer.kt
@@ -6,25 +6,25 @@ package com.delphix.sdk.objects
 /**
  * Data container for AppData.
  */
-open class AppDataContainer (
-    override val group: String? = null,//A reference to the group containing this container.
-    override val name: String? = null,//Object name.
-    open val toolkit: String? = null,//The toolkit managing the data in the container.
-    override val runtime: DBContainerRuntime? = null,//Runtime properties of this container.
-    override val restoration: Boolean? = null,//True if this container is part of a restoration dataset.
-    override val os: String? = null,//Native operating system of the original database source system.
-    override val performanceMode: String? = null,//Whether to enable high performance mode.
-    override val processor: String? = null,//Native processor type of the original database source system.
-    override val sourcingPolicy: SourcingPolicy? = null,//Policies for managing LogSync and SnapSync across sources.
-    override val currentTimeflow: String? = null,//A reference to the currently active TimeFlow for this container.
-    override val previousTimeflow: String? = null,//A reference to the previous TimeFlow for this container.
-    override val creationTime: String? = null,//The date this container was created.
-    override val masked: Boolean? = null,//True if this container is a masked container.
-    override val description: String? = null,//Optional user-provided description for the container.
-    override val provisionContainer: String? = null,//A reference to the container this container was provisioned from.
-    override val transformation: Boolean? = null,//True if this container is a transformation container.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class AppDataContainer(
+    override val group: String? = null, // A reference to the group containing this container.
+    override val name: String? = null, // Object name.
+    open val toolkit: String? = null, // The toolkit managing the data in the container.
+    override val runtime: DBContainerRuntime? = null, // Runtime properties of this container.
+    override val restoration: Boolean? = null, // True if this container is part of a restoration dataset.
+    override val os: String? = null, // Native operating system of the original database source system.
+    override val performanceMode: String? = null, // Whether to enable high performance mode.
+    override val processor: String? = null, // Native processor type of the original database source system.
+    override val sourcingPolicy: SourcingPolicy? = null, // Policies for managing LogSync and SnapSync across sources.
+    override val currentTimeflow: String? = null, // A reference to the currently active TimeFlow for this container.
+    override val previousTimeflow: String? = null, // A reference to the previous TimeFlow for this container.
+    override val creationTime: String? = null, // The date this container was created.
+    override val masked: Boolean? = null, // True if this container is a masked container.
+    override val description: String? = null, // Optional user-provided description for the container.
+    override val provisionContainer: String? = null, // A reference to the container this container was provisioned from.
+    override val transformation: Boolean? = null, // True if this container is a transformation container.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "AppDataContainer"
 ) : DatabaseContainer {
     override fun toMap(): Map<String, Any?> {
@@ -51,4 +51,3 @@ open class AppDataContainer (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainerRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainerRuntime.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * Runtime properties of an AppData container.
  */
-open class AppDataContainerRuntime (
-    override val preProvisioningStatus: PreProvisioningRuntime? = null,//The pre-provisioning runtime for the container.
-    override val logSyncActive: Boolean? = null,//True if the LogSync is enabled and running for this container.
+open class AppDataContainerRuntime(
+    override val preProvisioningStatus: PreProvisioningRuntime? = null, // The pre-provisioning runtime for the container.
+    override val logSyncActive: Boolean? = null, // True if the LogSync is enabled and running for this container.
     override val type: String = "AppDataContainerRuntime"
 ) : DBContainerRuntime {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class AppDataContainerRuntime (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainerRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataContainerRuntime.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime properties of an AppData container.
+ */
+open class AppDataContainerRuntime (
+    override val preProvisioningStatus: PreProvisioningRuntime? = null,//The pre-provisioning runtime for the container.
+    override val logSyncActive: Boolean? = null,//True if the LogSync is enabled and running for this container.
+    override val type: String = "AppDataContainerRuntime"
+) : DBContainerRuntime {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "preProvisioningStatus" to preProvisioningStatus,
+            "logSyncActive" to logSyncActive,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataDirectSourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataDirectSourceConfig.kt
@@ -6,17 +6,17 @@ package com.delphix.sdk.objects
 /**
  * Source config for directly linked AppData sources.
  */
-open class AppDataDirectSourceConfig (
-    open val path: String? = null,//The path to the data to be synced.
-    open val restoration: Boolean? = null,//True if this source config is part of a restoration dataset.
-    override val name: String? = null,//Object name.
-    override val repository: String? = null,//The object reference of the source repository.
-    override val parameters: Map<String, Any>? = null,//The list of parameters specified by the source config schema in the toolkit. If no schema is specified, this list is empty.
-    override val discovered: Boolean? = null,//Whether this source was discovered.
-    override val environmentUser: String? = null,//The user used to create and manage the configuration.
-    override val linkingEnabled: Boolean? = null,//Whether this source should be used for linking.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class AppDataDirectSourceConfig(
+    open val path: String? = null, // The path to the data to be synced.
+    open val restoration: Boolean? = null, // True if this source config is part of a restoration dataset.
+    override val name: String? = null, // Object name.
+    override val repository: String? = null, // The object reference of the source repository.
+    override val parameters: Map<String, Any>? = null, // The list of parameters specified by the source config schema in the toolkit. If no schema is specified, this list is empty.
+    override val discovered: Boolean? = null, // Whether this source was discovered.
+    override val environmentUser: String? = null, // The user used to create and manage the configuration.
+    override val linkingEnabled: Boolean? = null, // Whether this source should be used for linking.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "AppDataDirectSourceConfig"
 ) : AppDataSourceConfig {
     override fun toMap(): Map<String, Any?> {
@@ -35,4 +35,3 @@ open class AppDataDirectSourceConfig (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataDirectSourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataDirectSourceConfig.kt
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Source config for directly linked AppData sources.
+ */
+open class AppDataDirectSourceConfig (
+    open val path: String? = null,//The path to the data to be synced.
+    open val restoration: Boolean? = null,//True if this source config is part of a restoration dataset.
+    override val name: String? = null,//Object name.
+    override val repository: String? = null,//The object reference of the source repository.
+    override val parameters: Map<String, Any>? = null,//The list of parameters specified by the source config schema in the toolkit. If no schema is specified, this list is empty.
+    override val discovered: Boolean? = null,//Whether this source was discovered.
+    override val environmentUser: String? = null,//The user used to create and manage the configuration.
+    override val linkingEnabled: Boolean? = null,//Whether this source should be used for linking.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "AppDataDirectSourceConfig"
+) : AppDataSourceConfig {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "path" to path,
+            "restoration" to restoration,
+            "name" to name,
+            "repository" to repository,
+            "parameters" to parameters,
+            "discovered" to discovered,
+            "environmentUser" to environmentUser,
+            "linkingEnabled" to linkingEnabled,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataFilesystemLayout.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataFilesystemLayout.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A filesystem layout that matches the filesystem of a Delphix TimeFlow.
+ */
+open class AppDataFilesystemLayout (
+    open val targetDirectory: String? = null,//The base directory to use for the exported database.
+    override val type: String = "AppDataFilesystemLayout"
+) : FilesystemLayout {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "targetDirectory" to targetDirectory,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataFilesystemLayout.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataFilesystemLayout.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * A filesystem layout that matches the filesystem of a Delphix TimeFlow.
  */
-open class AppDataFilesystemLayout (
-    open val targetDirectory: String? = null,//The base directory to use for the exported database.
+open class AppDataFilesystemLayout(
+    open val targetDirectory: String? = null, // The base directory to use for the exported database.
     override val type: String = "AppDataFilesystemLayout"
 ) : FilesystemLayout {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class AppDataFilesystemLayout (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataManagedSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataManagedSource.kt
@@ -7,18 +7,18 @@ package com.delphix.sdk.objects
  * An AppData source managed by Delphix.
  */
 interface AppDataManagedSource : AppDataSource {
-    override val runtime: SourceRuntime?//Runtime properties of this source.
-    override val container: String?//Reference to the container being fed by this source, if any.
-    override val virtual: Boolean?//Flag indicating whether the source is a virtual source in the Delphix system.
-    override val description: String?//A user-provided description of the source.
-    override val config: String?//Reference to the configuration for the source.
-    override val staging: Boolean?//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
-    override val restoration: Boolean?//Flag indicating whether the source is a restoration source in the Delphix system.
-    override val linked: Boolean?//Flag indicating whether the source is a linked source in the Delphix system.
-    override val status: String?//Status of this source.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val runtime: SourceRuntime? // Runtime properties of this source.
+    override val container: String? // Reference to the container being fed by this source, if any.
+    override val virtual: Boolean? // Flag indicating whether the source is a virtual source in the Delphix system.
+    override val description: String? // A user-provided description of the source.
+    override val config: String? // Reference to the configuration for the source.
+    override val staging: Boolean? // Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    override val restoration: Boolean? // Flag indicating whether the source is a restoration source in the Delphix system.
+    override val linked: Boolean? // Flag indicating whether the source is a linked source in the Delphix system.
+    override val status: String? // Status of this source.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataManagedSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataManagedSource.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * An AppData source managed by Delphix.
+ */
+interface AppDataManagedSource : AppDataSource {
+    override val runtime: SourceRuntime?//Runtime properties of this source.
+    override val container: String?//Reference to the container being fed by this source, if any.
+    override val virtual: Boolean?//Flag indicating whether the source is a virtual source in the Delphix system.
+    override val description: String?//A user-provided description of the source.
+    override val config: String?//Reference to the configuration for the source.
+    override val staging: Boolean?//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    override val restoration: Boolean?//Flag indicating whether the source is a restoration source in the Delphix system.
+    override val linked: Boolean?//Flag indicating whether the source is a linked source in the Delphix system.
+    override val status: String?//Status of this source.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataProvisionParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataProvisionParameters.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input to provision AppData.
+ */
+open class AppDataProvisionParameters (
+    override val container: Container? = null,//The new container for the created dataset.
+    override val sourceConfig: SourceConfig? = null,//The source config including dynamically discovered attributes of the source.
+    override val source: Source? = null,//The source that describes an external dataset instance.
+    override val timeflowPointParameters: TimeflowPointParameters? = null,//The TimeFlow point, bookmark, or semantic location to base provisioning on.
+    override val maskingJob: String? = null,//The Masking Job to be run when this dataset is provisioned or refreshed.
+    override val type: String = "AppDataProvisionParameters"
+) : ProvisionParameters {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "container" to container,
+            "sourceConfig" to sourceConfig,
+            "source" to source,
+            "timeflowPointParameters" to timeflowPointParameters,
+            "maskingJob" to maskingJob,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataProvisionParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataProvisionParameters.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input to provision AppData.
  */
-open class AppDataProvisionParameters (
-    override val container: Container? = null,//The new container for the created dataset.
-    override val sourceConfig: SourceConfig? = null,//The source config including dynamically discovered attributes of the source.
-    override val source: Source? = null,//The source that describes an external dataset instance.
-    override val timeflowPointParameters: TimeflowPointParameters? = null,//The TimeFlow point, bookmark, or semantic location to base provisioning on.
-    override val maskingJob: String? = null,//The Masking Job to be run when this dataset is provisioned or refreshed.
+open class AppDataProvisionParameters(
+    override val container: Container? = null, // The new container for the created dataset.
+    override val sourceConfig: SourceConfig? = null, // The source config including dynamically discovered attributes of the source.
+    override val source: Source? = null, // The source that describes an external dataset instance.
+    override val timeflowPointParameters: TimeflowPointParameters? = null, // The TimeFlow point, bookmark, or semantic location to base provisioning on.
+    override val maskingJob: String? = null, // The Masking Job to be run when this dataset is provisioned or refreshed.
     override val type: String = "AppDataProvisionParameters"
 ) : ProvisionParameters {
     override fun toMap(): Map<String, Any?> {
@@ -25,4 +25,3 @@ open class AppDataProvisionParameters (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataRepository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataRepository.kt
@@ -6,17 +6,17 @@ package com.delphix.sdk.objects
 /**
  * An AppData repository.
  */
-open class AppDataRepository (
-    open val toolkit: String? = null,//The toolkit associated with this repository.
-    open val parameters: Json? = null,//The list of parameters specified by the repository schema in the toolkit. If no schema is specified, this list is empty.
-    override val environment: String? = null,//Reference to the environment containing this repository.
-    override val provisioningEnabled: Boolean? = null,//Flag indicating whether the repository should be used for provisioning.
-    override val linkingEnabled: Boolean? = null,//Flag indicating whether the repository should be used for linking.
-    override val staging: Boolean? = null,//Flag indicating whether this repository can be used by the Delphix Engine for internal processing.
-    override val version: String? = null,//Version of the repository.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class AppDataRepository(
+    open val toolkit: String? = null, // The toolkit associated with this repository.
+    open val parameters: Json? = null, // The list of parameters specified by the repository schema in the toolkit. If no schema is specified, this list is empty.
+    override val environment: String? = null, // Reference to the environment containing this repository.
+    override val provisioningEnabled: Boolean? = null, // Flag indicating whether the repository should be used for provisioning.
+    override val linkingEnabled: Boolean? = null, // Flag indicating whether the repository should be used for linking.
+    override val staging: Boolean? = null, // Flag indicating whether this repository can be used by the Delphix Engine for internal processing.
+    override val version: String? = null, // Version of the repository.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "AppDataRepository"
 ) : SourceRepository {
     override fun toMap(): Map<String, Any?> {
@@ -35,4 +35,3 @@ open class AppDataRepository (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataRepository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataRepository.kt
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * An AppData repository.
+ */
+open class AppDataRepository (
+    open val toolkit: String? = null,//The toolkit associated with this repository.
+    open val parameters: Json? = null,//The list of parameters specified by the repository schema in the toolkit. If no schema is specified, this list is empty.
+    override val environment: String? = null,//Reference to the environment containing this repository.
+    override val provisioningEnabled: Boolean? = null,//Flag indicating whether the repository should be used for provisioning.
+    override val linkingEnabled: Boolean? = null,//Flag indicating whether the repository should be used for linking.
+    override val staging: Boolean? = null,//Flag indicating whether this repository can be used by the Delphix Engine for internal processing.
+    override val version: String? = null,//Version of the repository.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "AppDataRepository"
+) : SourceRepository {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "toolkit" to toolkit,
+            "parameters" to parameters,
+            "environment" to environment,
+            "provisioningEnabled" to provisioningEnabled,
+            "linkingEnabled" to linkingEnabled,
+            "staging" to staging,
+            "version" to version,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshot.kt
@@ -6,23 +6,23 @@ package com.delphix.sdk.objects
 /**
  * Snapshot of an AppData TimeFlow.
  */
-open class AppDataSnapshot (
-    override val firstChangePoint: TimeflowPoint? = null,//The location within the parent TimeFlow at which this snapshot was initiated. No recovery earlier than this point needs to be applied in order to provision a database from this snapshot. If "firstChangePoint" equals "latestChangePoint", then no recovery needs to be applied in order to provision a database.
-    open val metadata: Json? = null,//The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
-    override val latestChangePoint: TimeflowPoint? = null,//The location of the snapshot within the parent TimeFlow represented by this snapshot.
-    override val runtime: SnapshotRuntime? = null,//Runtime properties of the snapshot.
-    override val container: String? = null,//Reference to the database of which this TimeFlow is a part.
-    override val temporary: Boolean? = null,//Boolean value indicating that this snapshot is in a transient state and should not be user visible.
-    override val missingNonLoggedData: Boolean? = null,//Boolean value indicating if a virtual database provisioned from this snapshot will be missing nologging changes.
-    override val creationTime: String? = null,//Point in time at which this snapshot was created. This may be different from the time corresponding to the TimeFlow.
-    override val timezone: String? = null,//Time zone of the source database at the time the snapshot was taken.
-    override val consistency: String? = null,//A value in the set {CONSISTENT, INCONSISTENT, CRASH_CONSISTENT} indicating what type of recovery strategies must be invoked when provisioning from this snapshot.
-    override val timeflow: String? = null,//TimeFlow of which this snapshot is a part.
-    override val version: String? = null,//Version of database source repository at the time the snapshot was taken.
-    override val retention: Int? = null,//Retention policy, in days. A value of -1 indicates the snapshot should be kept forever.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class AppDataSnapshot(
+    override val firstChangePoint: TimeflowPoint? = null, // The location within the parent TimeFlow at which this snapshot was initiated. No recovery earlier than this point needs to be applied in order to provision a database from this snapshot. If "firstChangePoint" equals "latestChangePoint", then no recovery needs to be applied in order to provision a database.
+    open val metadata: Json? = null, // The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
+    override val latestChangePoint: TimeflowPoint? = null, // The location of the snapshot within the parent TimeFlow represented by this snapshot.
+    override val runtime: SnapshotRuntime? = null, // Runtime properties of the snapshot.
+    override val container: String? = null, // Reference to the database of which this TimeFlow is a part.
+    override val temporary: Boolean? = null, // Boolean value indicating that this snapshot is in a transient state and should not be user visible.
+    override val missingNonLoggedData: Boolean? = null, // Boolean value indicating if a virtual database provisioned from this snapshot will be missing nologging changes.
+    override val creationTime: String? = null, // Point in time at which this snapshot was created. This may be different from the time corresponding to the TimeFlow.
+    override val timezone: String? = null, // Time zone of the source database at the time the snapshot was taken.
+    override val consistency: String? = null, // A value in the set {CONSISTENT, INCONSISTENT, CRASH_CONSISTENT} indicating what type of recovery strategies must be invoked when provisioning from this snapshot.
+    override val timeflow: String? = null, // TimeFlow of which this snapshot is a part.
+    override val version: String? = null, // Version of database source repository at the time the snapshot was taken.
+    override val retention: Int? = null, // Retention policy, in days. A value of -1 indicates the snapshot should be kept forever.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "AppDataSnapshot"
 ) : TimeflowSnapshot {
     override fun toMap(): Map<String, Any?> {
@@ -47,4 +47,3 @@ open class AppDataSnapshot (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshot.kt
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Snapshot of an AppData TimeFlow.
+ */
+open class AppDataSnapshot (
+    override val firstChangePoint: TimeflowPoint? = null,//The location within the parent TimeFlow at which this snapshot was initiated. No recovery earlier than this point needs to be applied in order to provision a database from this snapshot. If "firstChangePoint" equals "latestChangePoint", then no recovery needs to be applied in order to provision a database.
+    open val metadata: Json? = null,//The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
+    override val latestChangePoint: TimeflowPoint? = null,//The location of the snapshot within the parent TimeFlow represented by this snapshot.
+    override val runtime: SnapshotRuntime? = null,//Runtime properties of the snapshot.
+    override val container: String? = null,//Reference to the database of which this TimeFlow is a part.
+    override val temporary: Boolean? = null,//Boolean value indicating that this snapshot is in a transient state and should not be user visible.
+    override val missingNonLoggedData: Boolean? = null,//Boolean value indicating if a virtual database provisioned from this snapshot will be missing nologging changes.
+    override val creationTime: String? = null,//Point in time at which this snapshot was created. This may be different from the time corresponding to the TimeFlow.
+    override val timezone: String? = null,//Time zone of the source database at the time the snapshot was taken.
+    override val consistency: String? = null,//A value in the set {CONSISTENT, INCONSISTENT, CRASH_CONSISTENT} indicating what type of recovery strategies must be invoked when provisioning from this snapshot.
+    override val timeflow: String? = null,//TimeFlow of which this snapshot is a part.
+    override val version: String? = null,//Version of database source repository at the time the snapshot was taken.
+    override val retention: Int? = null,//Retention policy, in days. A value of -1 indicates the snapshot should be kept forever.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "AppDataSnapshot"
+) : TimeflowSnapshot {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "firstChangePoint" to firstChangePoint,
+            "metadata" to metadata,
+            "latestChangePoint" to latestChangePoint,
+            "runtime" to runtime,
+            "container" to container,
+            "temporary" to temporary,
+            "missingNonLoggedData" to missingNonLoggedData,
+            "creationTime" to creationTime,
+            "timezone" to timezone,
+            "consistency" to consistency,
+            "timeflow" to timeflow,
+            "version" to version,
+            "retention" to retention,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshotRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshotRuntime.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * Runtime (non-persistent) properties of AppData TimeFlow snapshots.
  */
-open class AppDataSnapshotRuntime (
-    override val provisionable: Boolean? = null,//True if this snapshot can be used as the basis for provisioning a new TimeFlow.
+open class AppDataSnapshotRuntime(
+    override val provisionable: Boolean? = null, // True if this snapshot can be used as the basis for provisioning a new TimeFlow.
     override val type: String = "AppDataSnapshotRuntime"
 ) : SnapshotRuntime(
     provisionable
-){
+) {
     override fun toMap(): Map<String, Any?> {
         return mapOf(
             "provisionable" to provisionable,

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshotRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSnapshotRuntime.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime (non-persistent) properties of AppData TimeFlow snapshots.
+ */
+open class AppDataSnapshotRuntime (
+    override val provisionable: Boolean? = null,//True if this snapshot can be used as the basis for provisioning a new TimeFlow.
+    override val type: String = "AppDataSnapshotRuntime"
+) : SnapshotRuntime(
+    provisionable
+){
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "provisionable" to provisionable,
+            "type" to type
+        )
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSource.kt
@@ -7,18 +7,18 @@ package com.delphix.sdk.objects
  * An AppData source.
  */
 interface AppDataSource : Source {
-    override val runtime: SourceRuntime?//Runtime properties of this source.
-    override val container: String?//Reference to the container being fed by this source, if any.
-    override val virtual: Boolean?//Flag indicating whether the source is a virtual source in the Delphix system.
-    override val description: String?//A user-provided description of the source.
-    override val config: String?//Reference to the configuration for the source.
-    override val staging: Boolean?//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
-    override val restoration: Boolean?//Flag indicating whether the source is a restoration source in the Delphix system.
-    override val linked: Boolean?//Flag indicating whether the source is a linked source in the Delphix system.
-    override val status: String?//Status of this source.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val runtime: SourceRuntime? // Runtime properties of this source.
+    override val container: String? // Reference to the container being fed by this source, if any.
+    override val virtual: Boolean? // Flag indicating whether the source is a virtual source in the Delphix system.
+    override val description: String? // A user-provided description of the source.
+    override val config: String? // Reference to the configuration for the source.
+    override val staging: Boolean? // Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    override val restoration: Boolean? // Flag indicating whether the source is a restoration source in the Delphix system.
+    override val linked: Boolean? // Flag indicating whether the source is a linked source in the Delphix system.
+    override val status: String? // Status of this source.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSource.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * An AppData source.
+ */
+interface AppDataSource : Source {
+    override val runtime: SourceRuntime?//Runtime properties of this source.
+    override val container: String?//Reference to the container being fed by this source, if any.
+    override val virtual: Boolean?//Flag indicating whether the source is a virtual source in the Delphix system.
+    override val description: String?//A user-provided description of the source.
+    override val config: String?//Reference to the configuration for the source.
+    override val staging: Boolean?//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    override val restoration: Boolean?//Flag indicating whether the source is a restoration source in the Delphix system.
+    override val linked: Boolean?//Flag indicating whether the source is a linked source in the Delphix system.
+    override val status: String?//Status of this source.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConfig.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Base Source config for AppDataToolkits.
+ */
+interface AppDataSourceConfig : SourceConfig {
+    override val name: String?//Object name.
+    override val repository: String?//The object reference of the source repository.
+    val parameters: Map<String, Any>?//The list of parameters specified by the source config schema in the toolkit. If no schema is specified, this list is empty.
+    override val discovered: Boolean?//Whether this source was discovered.
+    override val environmentUser: String?//The user used to create and manage the configuration.
+    override val linkingEnabled: Boolean?//Whether this source should be used for linking.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConfig.kt
@@ -7,14 +7,14 @@ package com.delphix.sdk.objects
  * Base Source config for AppDataToolkits.
  */
 interface AppDataSourceConfig : SourceConfig {
-    override val name: String?//Object name.
-    override val repository: String?//The object reference of the source repository.
-    val parameters: Map<String, Any>?//The list of parameters specified by the source config schema in the toolkit. If no schema is specified, this list is empty.
-    override val discovered: Boolean?//Whether this source was discovered.
-    override val environmentUser: String?//The user used to create and manage the configuration.
-    override val linkingEnabled: Boolean?//Whether this source should be used for linking.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val name: String? // Object name.
+    override val repository: String? // The object reference of the source repository.
+    val parameters: Map<String, Any>? // The list of parameters specified by the source config schema in the toolkit. If no schema is specified, this list is empty.
+    override val discovered: Boolean? // Whether this source was discovered.
+    override val environmentUser: String? // The user used to create and manage the configuration.
+    override val linkingEnabled: Boolean? // Whether this source should be used for linking.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConnectionInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConnectionInfo.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Contains information that can be used to connect to the application source.
+ */
+open class AppDataSourceConnectionInfo (
+    open val path: String? = null,//The path where the application data is located on the host.
+    open val host: String? = null,//The hostname or IP address of the host where the source resides.
+    override val version: String? = null,//The database version string.
+    override val type: String = "AppDataSourceConnectionInfo"
+) : SourceConnectionInfo {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "path" to path,
+            "host" to host,
+            "version" to version,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConnectionInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceConnectionInfo.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * Contains information that can be used to connect to the application source.
  */
-open class AppDataSourceConnectionInfo (
-    open val path: String? = null,//The path where the application data is located on the host.
-    open val host: String? = null,//The hostname or IP address of the host where the source resides.
-    override val version: String? = null,//The database version string.
+open class AppDataSourceConnectionInfo(
+    open val path: String? = null, // The path where the application data is located on the host.
+    open val host: String? = null, // The hostname or IP address of the host where the source resides.
+    override val version: String? = null, // The database version string.
     override val type: String = "AppDataSourceConnectionInfo"
 ) : SourceConnectionInfo {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class AppDataSourceConnectionInfo (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceRuntime.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * Runtime (non-persistent) properties of an AppData source.
  */
-open class AppDataSourceRuntime (
-    override val accessible: Boolean? = null,//True if the source is JDBC accessible. If false then no properties can be retrieved.
-    override val databaseSize: Int? = null,//Size of the database in bytes.
-    override val enabled: String? = null,//Status indicating whether the source is enabled. A source has a 'PARTIAL' status if its sub-sources are not all enabled.
-    override val notAccessibleReason: String? = null,//The reason why the source is not JDBC accessible.
-    override val status: String? = null,//Status of the source. 'Unknown' if all attempts to connect to the source failed.
+open class AppDataSourceRuntime(
+    override val accessible: Boolean? = null, // True if the source is JDBC accessible. If false then no properties can be retrieved.
+    override val databaseSize: Int? = null, // Size of the database in bytes.
+    override val enabled: String? = null, // Status indicating whether the source is enabled. A source has a 'PARTIAL' status if its sub-sources are not all enabled.
+    override val notAccessibleReason: String? = null, // The reason why the source is not JDBC accessible.
+    override val status: String? = null, // Status of the source. 'Unknown' if all attempts to connect to the source failed.
     override val type: String = "AppDataSourceRuntime"
 ) : SourceRuntime {
     override fun toMap(): Map<String, Any?> {
@@ -25,4 +25,3 @@ open class AppDataSourceRuntime (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSourceRuntime.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime (non-persistent) properties of an AppData source.
+ */
+open class AppDataSourceRuntime (
+    override val accessible: Boolean? = null,//True if the source is JDBC accessible. If false then no properties can be retrieved.
+    override val databaseSize: Int? = null,//Size of the database in bytes.
+    override val enabled: String? = null,//Status indicating whether the source is enabled. A source has a 'PARTIAL' status if its sub-sources are not all enabled.
+    override val notAccessibleReason: String? = null,//The reason why the source is not JDBC accessible.
+    override val status: String? = null,//Status of the source. 'Unknown' if all attempts to connect to the source failed.
+    override val type: String = "AppDataSourceRuntime"
+) : SourceRuntime {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "accessible" to accessible,
+            "databaseSize" to databaseSize,
+            "enabled" to enabled,
+            "notAccessibleReason" to notAccessibleReason,
+            "status" to status,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSyncParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSyncParameters.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input to sync an AppData source.
+ */
+open class AppDataSyncParameters (
+    open val resync: Boolean? = null,//Whether or not to force a non-incremental load of data prior to taking a snapshot.
+    override val type: String = "AppDataSyncParameters"
+) : SyncParameters(
+){
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "resync" to resync,
+            "type" to type
+        )
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSyncParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataSyncParameters.kt
@@ -6,11 +6,10 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input to sync an AppData source.
  */
-open class AppDataSyncParameters (
-    open val resync: Boolean? = null,//Whether or not to force a non-incremental load of data prior to taking a snapshot.
+open class AppDataSyncParameters(
+    open val resync: Boolean? = null, // Whether or not to force a non-incremental load of data prior to taking a snapshot.
     override val type: String = "AppDataSyncParameters"
-) : SyncParameters(
-){
+) : SyncParameters() {
     override fun toMap(): Map<String, Any?> {
         return mapOf(
             "resync" to resync,

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflow.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflow.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow representing historical data for a particular timeline within a data container.
+ */
+open class AppDataTimeflow (
+    override val parentPoint: TimeflowPoint? = null,//The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
+    override val container: String? = null,//Reference to the data container (database) for this TimeFlow.
+    override val creationType: String? = null,//The source action that created the TimeFlow.
+    override val parentSnapshot: String? = null,//Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "AppDataTimeflow"
+) : AppDataBaseTimeflow {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "parentPoint" to parentPoint,
+            "container" to container,
+            "creationType" to creationType,
+            "parentSnapshot" to parentSnapshot,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflow.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflow.kt
@@ -6,14 +6,14 @@ package com.delphix.sdk.objects
 /**
  * TimeFlow representing historical data for a particular timeline within a data container.
  */
-open class AppDataTimeflow (
-    override val parentPoint: TimeflowPoint? = null,//The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
-    override val container: String? = null,//Reference to the data container (database) for this TimeFlow.
-    override val creationType: String? = null,//The source action that created the TimeFlow.
-    override val parentSnapshot: String? = null,//Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class AppDataTimeflow(
+    override val parentPoint: TimeflowPoint? = null, // The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
+    override val container: String? = null, // Reference to the data container (database) for this TimeFlow.
+    override val creationType: String? = null, // The source action that created the TimeFlow.
+    override val parentSnapshot: String? = null, // Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "AppDataTimeflow"
 ) : AppDataBaseTimeflow {
     override fun toMap(): Map<String, Any?> {
@@ -29,4 +29,3 @@ open class AppDataTimeflow (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflowPoint.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflowPoint.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * A unique point within an AppData TimeFlow.
  */
-open class AppDataTimeflowPoint (
-    override val location: String? = null,//The TimeFlow location.
-    override val timeflow: String? = null,//Reference to TimeFlow containing this point.
-    override val timestamp: String? = null,//The logical time corresponding to the TimeFlow location.
+open class AppDataTimeflowPoint(
+    override val location: String? = null, // The TimeFlow location.
+    override val timeflow: String? = null, // Reference to TimeFlow containing this point.
+    override val timestamp: String? = null, // The logical time corresponding to the TimeFlow location.
     override val type: String = "AppDataTimeflowPoint"
 ) : TimeflowPoint {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class AppDataTimeflowPoint (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflowPoint.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataTimeflowPoint.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A unique point within an AppData TimeFlow.
+ */
+open class AppDataTimeflowPoint (
+    override val location: String? = null,//The TimeFlow location.
+    override val timeflow: String? = null,//Reference to TimeFlow containing this point.
+    override val timestamp: String? = null,//The logical time corresponding to the TimeFlow location.
+    override val type: String = "AppDataTimeflowPoint"
+) : TimeflowPoint {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "location" to location,
+            "timeflow" to timeflow,
+            "timestamp" to timestamp,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataVirtualSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataVirtualSource.kt
@@ -6,22 +6,22 @@ package com.delphix.sdk.objects
 /**
  * A virtual AppData source.
  */
-open class AppDataVirtualSource (
-    open val operations: VirtualSourceOperations? = null,//User-specified operation hooks for this source.
-    open val additionalMountPoints: List<AppDataAdditionalMountPoint>? = null,//Locations to mount subdirectories of the AppData in addition to the normal target mount point. These paths will be mounted and unmounted as part of enabling and disabling this source.
-    open val parameters: Map<String, Any>? = null,//The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
-    override val runtime: SourceRuntime? = null,//Runtime properties of this source.
-    override val container: String? = null,//Reference to the container being fed by this source, if any.
-    override val virtual: Boolean? = null,//Flag indicating whether the source is a virtual source in the Delphix system.
-    override val description: String? = null,//A user-provided description of the source.
-    override val config: String? = null,//Reference to the configuration for the source.
-    override val staging: Boolean? = null,//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
-    override val restoration: Boolean? = null,//Flag indicating whether the source is a restoration source in the Delphix system.
-    override val linked: Boolean? = null,//Flag indicating whether the source is a linked source in the Delphix system.
-    override val status: String? = null,//Status of this source.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class AppDataVirtualSource(
+    open val operations: VirtualSourceOperations? = null, // User-specified operation hooks for this source.
+    open val additionalMountPoints: List<AppDataAdditionalMountPoint>? = null, // Locations to mount subdirectories of the AppData in addition to the normal target mount point. These paths will be mounted and unmounted as part of enabling and disabling this source.
+    open val parameters: Map<String, Any>? = null, // The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
+    override val runtime: SourceRuntime? = null, // Runtime properties of this source.
+    override val container: String? = null, // Reference to the container being fed by this source, if any.
+    override val virtual: Boolean? = null, // Flag indicating whether the source is a virtual source in the Delphix system.
+    override val description: String? = null, // A user-provided description of the source.
+    override val config: String? = null, // Reference to the configuration for the source.
+    override val staging: Boolean? = null, // Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    override val restoration: Boolean? = null, // Flag indicating whether the source is a restoration source in the Delphix system.
+    override val linked: Boolean? = null, // Flag indicating whether the source is a linked source in the Delphix system.
+    override val status: String? = null, // Status of this source.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "AppDataVirtualSource"
 ) : AppDataManagedSource {
     override fun toMap(): Map<String, Any?> {
@@ -45,4 +45,3 @@ open class AppDataVirtualSource (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataVirtualSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/AppDataVirtualSource.kt
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A virtual AppData source.
+ */
+open class AppDataVirtualSource (
+    open val operations: VirtualSourceOperations? = null,//User-specified operation hooks for this source.
+    open val additionalMountPoints: List<AppDataAdditionalMountPoint>? = null,//Locations to mount subdirectories of the AppData in addition to the normal target mount point. These paths will be mounted and unmounted as part of enabling and disabling this source.
+    open val parameters: Map<String, Any>? = null,//The JSON payload conforming to the DraftV4 schema based on the type of application data being manipulated.
+    override val runtime: SourceRuntime? = null,//Runtime properties of this source.
+    override val container: String? = null,//Reference to the container being fed by this source, if any.
+    override val virtual: Boolean? = null,//Flag indicating whether the source is a virtual source in the Delphix system.
+    override val description: String? = null,//A user-provided description of the source.
+    override val config: String? = null,//Reference to the configuration for the source.
+    override val staging: Boolean? = null,//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    override val restoration: Boolean? = null,//Flag indicating whether the source is a restoration source in the Delphix system.
+    override val linked: Boolean? = null,//Flag indicating whether the source is a linked source in the Delphix system.
+    override val status: String? = null,//Status of this source.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "AppDataVirtualSource"
+) : AppDataManagedSource {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "operations" to operations,
+            "additionalMountPoints" to additionalMountPoints,
+            "parameters" to parameters,
+            "runtime" to runtime,
+            "container" to container,
+            "virtual" to virtual,
+            "description" to description,
+            "config" to config,
+            "staging" to staging,
+            "restoration" to restoration,
+            "linked" to linked,
+            "status" to status,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/CPUInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/CPUInfo.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Describes a processor available to the system.
+ */
+open class CPUInfo (
+    open val cores: Int? = null,//Number of cores in the processor.
+    open val speed: Int? = null,//Speed of the processor, in hertz.
+    override val type: String = "CPUInfo"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "cores" to cores,
+            "speed" to speed,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/CPUInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/CPUInfo.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * Describes a processor available to the system.
  */
-open class CPUInfo (
-    open val cores: Int? = null,//Number of cores in the processor.
-    open val speed: Int? = null,//Speed of the processor, in hertz.
+open class CPUInfo(
+    open val cores: Int? = null, // Number of cores in the processor.
+    open val speed: Int? = null, // Speed of the processor, in hertz.
     override val type: String = "CPUInfo"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class CPUInfo (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/CallResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/CallResult.kt
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Result of an API call.
+ */
+interface CallResult : TypedObject {
+    val status: String?//Indicates whether an error occurred during the call.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/CallResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/CallResult.kt
@@ -7,7 +7,7 @@ package com.delphix.sdk.objects
  * Result of an API call.
  */
 interface CallResult : TypedObject {
-    val status: String?//Indicates whether an error occurred during the call.
+    val status: String? // Indicates whether an error occurred during the call.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Container.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Container.kt
@@ -7,19 +7,19 @@ package com.delphix.sdk.objects
  * A container holding data.
  */
 interface Container : NamedUserObject {
-    val currentTimeflow: String?//A reference to the currently active TimeFlow for this container.
-    val previousTimeflow: String?//A reference to the previous TimeFlow for this container.
-    val creationTime: String?//The date this container was created.
-    val masked: Boolean?//True if this container is a masked container.
-    val description: String?//Optional user-provided description for the container.
-    val provisionContainer: String?//A reference to the container this container was provisioned from.
-    val runtime: DBContainerRuntime?//Runtime properties of this container.
-    val transformation: Boolean?//True if this container is a transformation container.
-    val restoration: Boolean?//True if this container is part of a restoration dataset.
-    val group: String?//A reference to the group containing this container.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val currentTimeflow: String? // A reference to the currently active TimeFlow for this container.
+    val previousTimeflow: String? // A reference to the previous TimeFlow for this container.
+    val creationTime: String? // The date this container was created.
+    val masked: Boolean? // True if this container is a masked container.
+    val description: String? // Optional user-provided description for the container.
+    val provisionContainer: String? // A reference to the container this container was provisioned from.
+    val runtime: DBContainerRuntime? // Runtime properties of this container.
+    val transformation: Boolean? // True if this container is a transformation container.
+    val restoration: Boolean? // True if this container is part of a restoration dataset.
+    val group: String? // A reference to the group containing this container.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Container.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Container.kt
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A container holding data.
+ */
+interface Container : NamedUserObject {
+    val currentTimeflow: String?//A reference to the currently active TimeFlow for this container.
+    val previousTimeflow: String?//A reference to the previous TimeFlow for this container.
+    val creationTime: String?//The date this container was created.
+    val masked: Boolean?//True if this container is a masked container.
+    val description: String?//Optional user-provided description for the container.
+    val provisionContainer: String?//A reference to the container this container was provisioned from.
+    val runtime: DBContainerRuntime?//Runtime properties of this container.
+    val transformation: Boolean?//True if this container is a transformation container.
+    val restoration: Boolean?//True if this container is part of a restoration dataset.
+    val group: String?//A reference to the group containing this container.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Credential.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Credential.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The security credential.
+ */
+interface Credential : TypedObject {
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DBContainerRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DBContainerRuntime.kt
@@ -7,8 +7,8 @@ package com.delphix.sdk.objects
  * Runtime properties of a database container.
  */
 interface DBContainerRuntime : TypedObject {
-    val preProvisioningStatus: PreProvisioningRuntime?//The pre-provisioning runtime for the container.
-    val logSyncActive: Boolean?//True if the LogSync is enabled and running for this container.
+    val preProvisioningStatus: PreProvisioningRuntime? // The pre-provisioning runtime for the container.
+    val logSyncActive: Boolean? // True if the LogSync is enabled and running for this container.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DBContainerRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DBContainerRuntime.kt
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime properties of a database container.
+ */
+interface DBContainerRuntime : TypedObject {
+    val preProvisioningStatus: PreProvisioningRuntime?//The pre-provisioning runtime for the container.
+    val logSyncActive: Boolean?//True if the LogSync is enabled and running for this container.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DatabaseContainer.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DatabaseContainer.kt
@@ -7,23 +7,23 @@ package com.delphix.sdk.objects
  * A container holding database data.
  */
 interface DatabaseContainer : Container {
-    val os: String?//Native operating system of the original database source system.
-    val performanceMode: String?//Whether to enable high performance mode.
-    val processor: String?//Native processor type of the original database source system.
-    val sourcingPolicy: SourcingPolicy?//Policies for managing LogSync and SnapSync across sources.
-    override val currentTimeflow: String?//A reference to the currently active TimeFlow for this container.
-    override val previousTimeflow: String?//A reference to the previous TimeFlow for this container.
-    override val creationTime: String?//The date this container was created.
-    override val masked: Boolean?//True if this container is a masked container.
-    override val description: String?//Optional user-provided description for the container.
-    override val provisionContainer: String?//A reference to the container this container was provisioned from.
-    override val runtime: DBContainerRuntime?//Runtime properties of this container.
-    override val transformation: Boolean?//True if this container is a transformation container.
-    override val restoration: Boolean?//True if this container is part of a restoration dataset.
-    override val group: String?//A reference to the group containing this container.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val os: String? // Native operating system of the original database source system.
+    val performanceMode: String? // Whether to enable high performance mode.
+    val processor: String? // Native processor type of the original database source system.
+    val sourcingPolicy: SourcingPolicy? // Policies for managing LogSync and SnapSync across sources.
+    override val currentTimeflow: String? // A reference to the currently active TimeFlow for this container.
+    override val previousTimeflow: String? // A reference to the previous TimeFlow for this container.
+    override val creationTime: String? // The date this container was created.
+    override val masked: Boolean? // True if this container is a masked container.
+    override val description: String? // Optional user-provided description for the container.
+    override val provisionContainer: String? // A reference to the container this container was provisioned from.
+    override val runtime: DBContainerRuntime? // Runtime properties of this container.
+    override val transformation: Boolean? // True if this container is a transformation container.
+    override val restoration: Boolean? // True if this container is part of a restoration dataset.
+    override val group: String? // A reference to the group containing this container.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DatabaseContainer.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DatabaseContainer.kt
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A container holding database data.
+ */
+interface DatabaseContainer : Container {
+    val os: String?//Native operating system of the original database source system.
+    val performanceMode: String?//Whether to enable high performance mode.
+    val processor: String?//Native processor type of the original database source system.
+    val sourcingPolicy: SourcingPolicy?//Policies for managing LogSync and SnapSync across sources.
+    override val currentTimeflow: String?//A reference to the currently active TimeFlow for this container.
+    override val previousTimeflow: String?//A reference to the previous TimeFlow for this container.
+    override val creationTime: String?//The date this container was created.
+    override val masked: Boolean?//True if this container is a masked container.
+    override val description: String?//Optional user-provided description for the container.
+    override val provisionContainer: String?//A reference to the container this container was provisioned from.
+    override val runtime: DBContainerRuntime?//Runtime properties of this container.
+    override val transformation: Boolean?//True if this container is a transformation container.
+    override val restoration: Boolean?//True if this container is part of a restoration dataset.
+    override val group: String?//A reference to the group containing this container.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DeleteParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DeleteParameters.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input to delete requests for MSSQL, PostgreSQL, AppData, ASE or MySQL.
  */
-open class DeleteParameters (
-    open val force: Boolean? = null,//Flag indicating whether to continue the operation upon failures.
+open class DeleteParameters(
+    open val force: Boolean? = null, // Flag indicating whether to continue the operation upon failures.
     override val type: String = "DeleteParameters"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class DeleteParameters (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DeleteParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DeleteParameters.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input to delete requests for MSSQL, PostgreSQL, AppData, ASE or MySQL.
+ */
+open class DeleteParameters (
+    open val force: Boolean? = null,//Flag indicating whether to continue the operation upon failures.
+    override val type: String = "DeleteParameters"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "force" to force,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DiagnosisResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DiagnosisResult.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * Details from a diagnosis check that was run due to a failed operation.
  */
-open class DiagnosisResult (
-    open val failure: Boolean? = null,//True if this was a check that did not pass.
-    open val messageCode: String? = null,//Message code associated with the event.
-    open val message: String? = null,//Localized message.
+open class DiagnosisResult(
+    open val failure: Boolean? = null, // True if this was a check that did not pass.
+    open val messageCode: String? = null, // Message code associated with the event.
+    open val message: String? = null, // Localized message.
     override val type: String = "DiagnosisResult"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class DiagnosisResult (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/DiagnosisResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/DiagnosisResult.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Details from a diagnosis check that was run due to a failed operation.
+ */
+open class DiagnosisResult (
+    open val failure: Boolean? = null,//True if this was a check that did not pass.
+    open val messageCode: String? = null,//Message code associated with the event.
+    open val message: String? = null,//Localized message.
+    override val type: String = "DiagnosisResult"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "failure" to failure,
+            "messageCode" to messageCode,
+            "message" to message,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Environment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Environment.kt
@@ -16,7 +16,7 @@ data class Environment(
     val logCollectionEnabled: Boolean,
     val primaryUser: String,
     val reference: String
-){
+) {
     companion object {
         @JvmStatic
         fun fromJson(node: JSONObject): Environment {

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Environment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Environment.kt
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.objects
+
+import org.json.JSONObject
+
+data class Environment(
+    val type: String,
+    val name: String,
+    val aseHostEnvironmentParameters: String,
+    val description: String,
+    val enabled: Boolean,
+    val host: String,
+    val logCollectionEnabled: Boolean,
+    val primaryUser: String,
+    val reference: String
+){
+    companion object {
+        @JvmStatic
+        fun fromJson(node: JSONObject): Environment {
+            val environment = Environment(
+                node.optString("type"),
+                node.optString("name"),
+                node.optString("aseHostEnvironmentParameters"),
+                node.optString("description"),
+                node.optBoolean("enabled"),
+                node.optString("host"),
+                node.optBoolean("logCollectionEnabled"),
+                node.optString("primaryUser"),
+                node.optString("reference")
+            )
+            return environment
+        }
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/EnvironmentUser.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/EnvironmentUser.kt
@@ -6,14 +6,14 @@ package com.delphix.sdk.objects
 /**
  * The representation of an environment user object.
  */
-open class EnvironmentUser (
-    open val environment: String? = null,//A reference to the associated environment.
-    open val credential: Credential? = null,//The credential for the environment user.
-    open val groupId: Int? = null,//Group ID of the user.
-    open val userId: Int? = null,//User ID of the user.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class EnvironmentUser(
+    open val environment: String? = null, // A reference to the associated environment.
+    open val credential: Credential? = null, // The credential for the environment user.
+    open val groupId: Int? = null, // Group ID of the user.
+    open val userId: Int? = null, // User ID of the user.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "EnvironmentUser"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -29,4 +29,3 @@ open class EnvironmentUser (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/EnvironmentUser.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/EnvironmentUser.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The representation of an environment user object.
+ */
+open class EnvironmentUser (
+    open val environment: String? = null,//A reference to the associated environment.
+    open val credential: Credential? = null,//The credential for the environment user.
+    open val groupId: Int? = null,//Group ID of the user.
+    open val userId: Int? = null,//User ID of the user.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "EnvironmentUser"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "environment" to environment,
+            "credential" to credential,
+            "groupId" to groupId,
+            "userId" to userId,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ErrorResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ErrorResult.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Result of a failed API call.
+ */
+open class ErrorResult (
+    open val error: APIError? = null,//Specifics of the error that occurred during API call execution.
+    override val status: String? = null,//Indicates whether an error occurred during the call.
+    override val type: String = "ErrorResult"
+) : CallResult {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "error" to error,
+            "status" to status,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ErrorResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ErrorResult.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * Result of a failed API call.
  */
-open class ErrorResult (
-    open val error: APIError? = null,//Specifics of the error that occurred during API call execution.
-    override val status: String? = null,//Indicates whether an error occurred during the call.
+open class ErrorResult(
+    open val error: APIError? = null, // Specifics of the error that occurred during API call execution.
+    override val status: String? = null, // Indicates whether an error occurred during the call.
     override val type: String = "ErrorResult"
 ) : CallResult {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class ErrorResult (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Fault.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Fault.kt
@@ -6,22 +6,22 @@ package com.delphix.sdk.objects
 /**
  * A representation of a fault, with associated user object.
  */
-open class Fault (
-    open val severity: String? = null,//The severity of the fault event. This can either be CRITICAL or WARNING.
-    open val targetName: String? = null,//The name of the faulted object at the time the fault was diagnosed.
-    open val bundleID: String? = null,//A unique dot delimited identifier associated with the fault.
-    open val description: String? = null,//Full description of the fault.
-    open val title: String? = null,//Summary of the fault.
-    open val target: String? = null,//The user-visible Delphix object that is faulted.
-    open val dateResolved: String? = null,//The date when the fault was resolved.
-    open val resolutionComments: String? = null,//A comment that describes the fault resolution.
-    open val response: String? = null,//The automated response taken by the system.
-    open val action: String? = null,//A suggested user action.
-    open val dateDiagnosed: String? = null,//The date when the fault was diagnosed.
-    open val targetObjectType: String? = null,//The user-visible Delphix object that is faulted.
-    open val status: String? = null,//The status of the fault. This can be ACTIVE, RESOLVED or IGNORED.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class Fault(
+    open val severity: String? = null, // The severity of the fault event. This can either be CRITICAL or WARNING.
+    open val targetName: String? = null, // The name of the faulted object at the time the fault was diagnosed.
+    open val bundleID: String? = null, // A unique dot delimited identifier associated with the fault.
+    open val description: String? = null, // Full description of the fault.
+    open val title: String? = null, // Summary of the fault.
+    open val target: String? = null, // The user-visible Delphix object that is faulted.
+    open val dateResolved: String? = null, // The date when the fault was resolved.
+    open val resolutionComments: String? = null, // A comment that describes the fault resolution.
+    open val response: String? = null, // The automated response taken by the system.
+    open val action: String? = null, // A suggested user action.
+    open val dateDiagnosed: String? = null, // The date when the fault was diagnosed.
+    open val targetObjectType: String? = null, // The user-visible Delphix object that is faulted.
+    open val status: String? = null, // The status of the fault. This can be ACTIVE, RESOLVED or IGNORED.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "Fault"
 ) : PersistentObject {
     override fun toMap(): Map<String, Any?> {
@@ -45,4 +45,3 @@ open class Fault (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Fault.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Fault.kt
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A representation of a fault, with associated user object.
+ */
+open class Fault (
+    open val severity: String? = null,//The severity of the fault event. This can either be CRITICAL or WARNING.
+    open val targetName: String? = null,//The name of the faulted object at the time the fault was diagnosed.
+    open val bundleID: String? = null,//A unique dot delimited identifier associated with the fault.
+    open val description: String? = null,//Full description of the fault.
+    open val title: String? = null,//Summary of the fault.
+    open val target: String? = null,//The user-visible Delphix object that is faulted.
+    open val dateResolved: String? = null,//The date when the fault was resolved.
+    open val resolutionComments: String? = null,//A comment that describes the fault resolution.
+    open val response: String? = null,//The automated response taken by the system.
+    open val action: String? = null,//A suggested user action.
+    open val dateDiagnosed: String? = null,//The date when the fault was diagnosed.
+    open val targetObjectType: String? = null,//The user-visible Delphix object that is faulted.
+    open val status: String? = null,//The status of the fault. This can be ACTIVE, RESOLVED or IGNORED.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "Fault"
+) : PersistentObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "severity" to severity,
+            "targetName" to targetName,
+            "bundleID" to bundleID,
+            "description" to description,
+            "title" to title,
+            "target" to target,
+            "dateResolved" to dateResolved,
+            "resolutionComments" to resolutionComments,
+            "response" to response,
+            "action" to action,
+            "dateDiagnosed" to dateDiagnosed,
+            "targetObjectType" to targetObjectType,
+            "status" to status,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/FaultEffect.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/FaultEffect.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * An error affecting a user object whose root cause is a fault. A fault effect can only be resolved by resolving the fault which is its root cause.
+ */
+open class FaultEffect (
+    open val severity: String? = null,//The severity of the fault effect. This can either be CRITICAL or WARNING.
+    open val targetName: String? = null,//The name of the user-visible Delphix object that has a fault effect.
+    open val response: String? = null,//The automated response taken by the system.
+    open val bundleID: String? = null,//A unique dot delimited identifier associated with the fault effect.
+    open val rootCause: String? = null,//The root cause of this fault effect. Resolving the fault effect can only occur by resolving its root cause.
+    open val action: String? = null,//A suggested user action.
+    open val causedBy: String? = null,//The cause of the fault effect, in case there is a chain of fault effects originating from the root cause which resulted in this effect.
+    open val description: String? = null,//Full description of the fault effect.
+    open val dateDiagnosed: String? = null,//The date when the root cause fault was diagnosed.
+    open val title: String? = null,//Summary of the fault effect.
+    open val target: String? = null,//The user-visible Delphix object that has a fault effect.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "FaultEffect"
+) : PersistentObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "severity" to severity,
+            "targetName" to targetName,
+            "response" to response,
+            "bundleID" to bundleID,
+            "rootCause" to rootCause,
+            "action" to action,
+            "causedBy" to causedBy,
+            "description" to description,
+            "dateDiagnosed" to dateDiagnosed,
+            "title" to title,
+            "target" to target,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/FaultEffect.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/FaultEffect.kt
@@ -6,20 +6,20 @@ package com.delphix.sdk.objects
 /**
  * An error affecting a user object whose root cause is a fault. A fault effect can only be resolved by resolving the fault which is its root cause.
  */
-open class FaultEffect (
-    open val severity: String? = null,//The severity of the fault effect. This can either be CRITICAL or WARNING.
-    open val targetName: String? = null,//The name of the user-visible Delphix object that has a fault effect.
-    open val response: String? = null,//The automated response taken by the system.
-    open val bundleID: String? = null,//A unique dot delimited identifier associated with the fault effect.
-    open val rootCause: String? = null,//The root cause of this fault effect. Resolving the fault effect can only occur by resolving its root cause.
-    open val action: String? = null,//A suggested user action.
-    open val causedBy: String? = null,//The cause of the fault effect, in case there is a chain of fault effects originating from the root cause which resulted in this effect.
-    open val description: String? = null,//Full description of the fault effect.
-    open val dateDiagnosed: String? = null,//The date when the root cause fault was diagnosed.
-    open val title: String? = null,//Summary of the fault effect.
-    open val target: String? = null,//The user-visible Delphix object that has a fault effect.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class FaultEffect(
+    open val severity: String? = null, // The severity of the fault effect. This can either be CRITICAL or WARNING.
+    open val targetName: String? = null, // The name of the user-visible Delphix object that has a fault effect.
+    open val response: String? = null, // The automated response taken by the system.
+    open val bundleID: String? = null, // A unique dot delimited identifier associated with the fault effect.
+    open val rootCause: String? = null, // The root cause of this fault effect. Resolving the fault effect can only occur by resolving its root cause.
+    open val action: String? = null, // A suggested user action.
+    open val causedBy: String? = null, // The cause of the fault effect, in case there is a chain of fault effects originating from the root cause which resulted in this effect.
+    open val description: String? = null, // Full description of the fault effect.
+    open val dateDiagnosed: String? = null, // The date when the root cause fault was diagnosed.
+    open val title: String? = null, // Summary of the fault effect.
+    open val target: String? = null, // The user-visible Delphix object that has a fault effect.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "FaultEffect"
 ) : PersistentObject {
     override fun toMap(): Map<String, Any?> {
@@ -41,4 +41,3 @@ open class FaultEffect (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/FileProcessingResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/FileProcessingResult.kt
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Result of a file processing request (upload or download).
+ */
+interface FileProcessingResult : TypedObject {
+    val url: String?//URL to download from or upload to.
+    val token: String?//Token to pass as parameter to identify the file.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/FileProcessingResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/FileProcessingResult.kt
@@ -7,8 +7,8 @@ package com.delphix.sdk.objects
  * Result of a file processing request (upload or download).
  */
 interface FileProcessingResult : TypedObject {
-    val url: String?//URL to download from or upload to.
-    val token: String?//Token to pass as parameter to identify the file.
+    val url: String? // URL to download from or upload to.
+    val token: String? // Token to pass as parameter to identify the file.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/FilesystemLayout.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/FilesystemLayout.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The filesystem configuration of a database.
+ */
+interface FilesystemLayout : TypedObject {
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Group.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Group.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * Database group.
  */
-open class Group (
-    open val description: String? = null,//Optional description for the group.
-    open val dataNode: String? = null,//The data node where databases of this group will be located.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class Group(
+    open val description: String? = null, // Optional description for the group.
+    open val dataNode: String? = null, // The data node where databases of this group will be located.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "Group"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -25,4 +25,3 @@ open class Group (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Group.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Group.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Database group.
+ */
+open class Group (
+    open val description: String? = null,//Optional description for the group.
+    open val dataNode: String? = null,//The data node where databases of this group will be located.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "Group"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "description" to description,
+            "dataNode" to dataNode,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Host.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Host.kt
@@ -7,15 +7,15 @@ package com.delphix.sdk.objects
  * The representation of a host object.
  */
 interface Host : ReadonlyNamedUserObject {
-    val privilegeElevationProfile: String?//Profile for escalating user privileges.
-    val sshPort: Int?//The port number used to connect to the host via SSH.
-    val hostRuntime: HostRuntime?//Runtime properties for this host.
-    val address: String?//The address associated with the host.
-    val hostConfiguration: HostConfiguration?//The host configuration object associated with the host.
-    val dateAdded: String?//The date the host was added.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val privilegeElevationProfile: String? // Profile for escalating user privileges.
+    val sshPort: Int? // The port number used to connect to the host via SSH.
+    val hostRuntime: HostRuntime? // Runtime properties for this host.
+    val address: String? // The address associated with the host.
+    val hostConfiguration: HostConfiguration? // The host configuration object associated with the host.
+    val dateAdded: String? // The date the host was added.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Host.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Host.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The representation of a host object.
+ */
+interface Host : ReadonlyNamedUserObject {
+    val privilegeElevationProfile: String?//Profile for escalating user privileges.
+    val sshPort: Int?//The port number used to connect to the host via SSH.
+    val hostRuntime: HostRuntime?//Runtime properties for this host.
+    val address: String?//The address associated with the host.
+    val hostConfiguration: HostConfiguration?//The host configuration object associated with the host.
+    val dateAdded: String?//The date the host was added.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostConfiguration.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostConfiguration.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The representation of the host configuration properties.
+ */
+open class HostConfiguration (
+    open val lastRefreshed: String? = null,//The timestamp when the host was last refreshed.
+    open val lastUpdated: String? = null,//The timestamp when the host was last updated.
+    open val discovered: Boolean? = null,//Indicates whether the host configuration properties were discovered.
+    open val machine: HostMachine? = null,//The host machine information.
+    open val operatingSystem: HostOS? = null,//The host operating system information.
+    override val type: String = "HostConfiguration"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "lastRefreshed" to lastRefreshed,
+            "lastUpdated" to lastUpdated,
+            "discovered" to discovered,
+            "machine" to machine,
+            "operatingSystem" to operatingSystem,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostConfiguration.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostConfiguration.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * The representation of the host configuration properties.
  */
-open class HostConfiguration (
-    open val lastRefreshed: String? = null,//The timestamp when the host was last refreshed.
-    open val lastUpdated: String? = null,//The timestamp when the host was last updated.
-    open val discovered: Boolean? = null,//Indicates whether the host configuration properties were discovered.
-    open val machine: HostMachine? = null,//The host machine information.
-    open val operatingSystem: HostOS? = null,//The host operating system information.
+open class HostConfiguration(
+    open val lastRefreshed: String? = null, // The timestamp when the host was last refreshed.
+    open val lastUpdated: String? = null, // The timestamp when the host was last updated.
+    open val discovered: Boolean? = null, // Indicates whether the host configuration properties were discovered.
+    open val machine: HostMachine? = null, // The host machine information.
+    open val operatingSystem: HostOS? = null, // The host operating system information.
     override val type: String = "HostConfiguration"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -25,4 +25,3 @@ open class HostConfiguration (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostEnvironment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostEnvironment.kt
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The representation of an host environment object.
+ */
+interface HostEnvironment : SourceEnvironment {
+    val host: String?//The reference to the associated host.
+    override val primaryUser: String?//A reference to the primary user for this environment.
+    override val description: String?//The environment description.
+    override val enabled: Boolean?//Indicates whether the source environment is enabled.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostEnvironment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostEnvironment.kt
@@ -7,13 +7,13 @@ package com.delphix.sdk.objects
  * The representation of an host environment object.
  */
 interface HostEnvironment : SourceEnvironment {
-    val host: String?//The reference to the associated host.
-    override val primaryUser: String?//A reference to the primary user for this environment.
-    override val description: String?//The environment description.
-    override val enabled: Boolean?//Indicates whether the source environment is enabled.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val host: String? // The reference to the associated host.
+    override val primaryUser: String? // A reference to the primary user for this environment.
+    override val description: String? // The environment description.
+    override val enabled: Boolean? // Indicates whether the source environment is enabled.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostMachine.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostMachine.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The representation of the host machine.
+ */
+open class HostMachine (
+    open val memorySize: Int? = null,//The amount of RAM on the host machine.
+    open val platform: String? = null,//The platform for the host machine.
+    override val type: String = "HostMachine"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "memorySize" to memorySize,
+            "platform" to platform,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostMachine.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostMachine.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * The representation of the host machine.
  */
-open class HostMachine (
-    open val memorySize: Int? = null,//The amount of RAM on the host machine.
-    open val platform: String? = null,//The platform for the host machine.
+open class HostMachine(
+    open val memorySize: Int? = null, // The amount of RAM on the host machine.
+    open val platform: String? = null, // The platform for the host machine.
     override val type: String = "HostMachine"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class HostMachine (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostOS.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostOS.kt
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The operating system information for the host.
+ */
+open class HostOS (
+    open val kernel: String? = null,//The OS kernel.
+    open val release: String? = null,//The OS release.
+    open val timezone: String? = null,//The OS timezone.
+    open val name: String? = null,//The OS name.
+    open val distribution: String? = null,//The OS distribution.
+    open val version: String? = null,//The OS version.
+    override val type: String = "HostOS"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "kernel" to kernel,
+            "release" to release,
+            "timezone" to timezone,
+            "name" to name,
+            "distribution" to distribution,
+            "version" to version,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostOS.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostOS.kt
@@ -6,13 +6,13 @@ package com.delphix.sdk.objects
 /**
  * The operating system information for the host.
  */
-open class HostOS (
-    open val kernel: String? = null,//The OS kernel.
-    open val release: String? = null,//The OS release.
-    open val timezone: String? = null,//The OS timezone.
-    open val name: String? = null,//The OS name.
-    open val distribution: String? = null,//The OS distribution.
-    open val version: String? = null,//The OS version.
+open class HostOS(
+    open val kernel: String? = null, // The OS kernel.
+    open val release: String? = null, // The OS release.
+    open val timezone: String? = null, // The OS timezone.
+    open val name: String? = null, // The OS name.
+    open val distribution: String? = null, // The OS distribution.
+    open val version: String? = null, // The OS version.
     override val type: String = "HostOS"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -27,4 +27,3 @@ open class HostOS (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostRuntime.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * Runtime, non-persistent properties for a host machine.
  */
-open class HostRuntime (
-    open val available: Boolean? = null,//True if the host is up and a connection can be established.
-    open val traceRouteInfo: TracerouteInfo? = null,//Traceroute network hops from host to Delphix Engine.
+open class HostRuntime(
+    open val available: Boolean? = null, // True if the host is up and a connection can be established.
+    open val traceRouteInfo: TracerouteInfo? = null, // Traceroute network hops from host to Delphix Engine.
     override val type: String = "HostRuntime"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class HostRuntime (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/HostRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/HostRuntime.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime, non-persistent properties for a host machine.
+ */
+open class HostRuntime (
+    open val available: Boolean? = null,//True if the host is up and a connection can be established.
+    open val traceRouteInfo: TracerouteInfo? = null,//Traceroute network hops from host to Delphix Engine.
+    override val type: String = "HostRuntime"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "available" to available,
+            "traceRouteInfo" to traceRouteInfo,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Job.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Job.kt
@@ -6,27 +6,27 @@ package com.delphix.sdk.objects
 /**
  * Represents a job object.
  */
-open class Job (
-    open val targetName: String? = null,//A cached copy of the target object name.
-    open val cancelable: Boolean? = null,//Whether this job can be canceled.
-    open val jobState: String? = null,//State of the job.
-    open val queued: Boolean? = null,//Whether this job is waiting for resources to be available for its execution.
-    open val updateTime: String? = null,//Time the job was last updated.
-    open val percentComplete: Int? = null,//Completion percentage. This value is a copy of the last event's percentComplete. It will be 0 if there are no job events or if the events field is not populated while fetching the job.
-    open val title: String? = null,//Title of the job.
-    open val parentActionState: String? = null,//State of this job's parent action. This value is populated only if the job is fetched via the plain get API call.
-    open val target: String? = null,//Object reference of the target.
-    open val actionType: String? = null,//Action type of the Job.
-    open val suspendable: Boolean? = null,//Whether this job can be suspended.
-    open val emailAddresses: List<String>,//Email addresses to be notified on job notification alerts.
-    open val startTime: String? = null,//Time the job was created. Note that this is not the time when the job started executing.
-    open val parentAction: String? = null,//This job's parent action.
-    open val targetObjectType: String? = null,//Object type of the target.
-    open val user: String? = null,//User that initiated the action.
-    open val events: List<JobEvent>,//A list of time-sorted past JobEvent objects associated with this job.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class Job(
+    open val targetName: String? = null, // A cached copy of the target object name.
+    open val cancelable: Boolean? = null, // Whether this job can be canceled.
+    open val jobState: String? = null, // State of the job.
+    open val queued: Boolean? = null, // Whether this job is waiting for resources to be available for its execution.
+    open val updateTime: String? = null, // Time the job was last updated.
+    open val percentComplete: Int? = null, // Completion percentage. This value is a copy of the last event's percentComplete. It will be 0 if there are no job events or if the events field is not populated while fetching the job.
+    open val title: String? = null, // Title of the job.
+    open val parentActionState: String? = null, // State of this job's parent action. This value is populated only if the job is fetched via the plain get API call.
+    open val target: String? = null, // Object reference of the target.
+    open val actionType: String? = null, // Action type of the Job.
+    open val suspendable: Boolean? = null, // Whether this job can be suspended.
+    open val emailAddresses: List<String>, // Email addresses to be notified on job notification alerts.
+    open val startTime: String? = null, // Time the job was created. Note that this is not the time when the job started executing.
+    open val parentAction: String? = null, // This job's parent action.
+    open val targetObjectType: String? = null, // Object type of the target.
+    open val user: String? = null, // User that initiated the action.
+    open val events: List<JobEvent>, // A list of time-sorted past JobEvent objects associated with this job.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "Job"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -55,4 +55,3 @@ open class Job (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Job.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Job.kt
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Represents a job object.
+ */
+open class Job (
+    open val targetName: String? = null,//A cached copy of the target object name.
+    open val cancelable: Boolean? = null,//Whether this job can be canceled.
+    open val jobState: String? = null,//State of the job.
+    open val queued: Boolean? = null,//Whether this job is waiting for resources to be available for its execution.
+    open val updateTime: String? = null,//Time the job was last updated.
+    open val percentComplete: Int? = null,//Completion percentage. This value is a copy of the last event's percentComplete. It will be 0 if there are no job events or if the events field is not populated while fetching the job.
+    open val title: String? = null,//Title of the job.
+    open val parentActionState: String? = null,//State of this job's parent action. This value is populated only if the job is fetched via the plain get API call.
+    open val target: String? = null,//Object reference of the target.
+    open val actionType: String? = null,//Action type of the Job.
+    open val suspendable: Boolean? = null,//Whether this job can be suspended.
+    open val emailAddresses: List<String>,//Email addresses to be notified on job notification alerts.
+    open val startTime: String? = null,//Time the job was created. Note that this is not the time when the job started executing.
+    open val parentAction: String? = null,//This job's parent action.
+    open val targetObjectType: String? = null,//Object type of the target.
+    open val user: String? = null,//User that initiated the action.
+    open val events: List<JobEvent>,//A list of time-sorted past JobEvent objects associated with this job.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "Job"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "targetName" to targetName,
+            "cancelable" to cancelable,
+            "jobState" to jobState,
+            "queued" to queued,
+            "updateTime" to updateTime,
+            "percentComplete" to percentComplete,
+            "title" to title,
+            "parentActionState" to parentActionState,
+            "target" to target,
+            "actionType" to actionType,
+            "suspendable" to suspendable,
+            "emailAddresses" to emailAddresses,
+            "startTime" to startTime,
+            "parentAction" to parentAction,
+            "targetObjectType" to targetObjectType,
+            "user" to user,
+            "events" to events,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/JobEvent.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/JobEvent.kt
@@ -6,16 +6,16 @@ package com.delphix.sdk.objects
 /**
  * Represents a job event object. This can either be a state change or a progress update.
  */
-open class JobEvent (
-    open val messageCommandOutput: String? = null,//Command output associated with the event, if applicable.
-    open val messageDetails: String? = null,//Localized message details.
-    open val messageAction: String? = null,//Localized message action.
-    open val messageCode: String? = null,//Message ID associated with the event.
-    open val eventType: String? = null,//Type of event.
-    open val percentComplete: Int? = null,//Completion percentage.
-    open val state: String? = null,//New state of the job.
-    open val diagnoses: List<DiagnosisResult>,//Results of diagnostic checks run, if any, if the job failed.
-    open val timestamp: String? = null,//Time the event occurred.
+open class JobEvent(
+    open val messageCommandOutput: String? = null, // Command output associated with the event, if applicable.
+    open val messageDetails: String? = null, // Localized message details.
+    open val messageAction: String? = null, // Localized message action.
+    open val messageCode: String? = null, // Message ID associated with the event.
+    open val eventType: String? = null, // Type of event.
+    open val percentComplete: Int? = null, // Completion percentage.
+    open val state: String? = null, // New state of the job.
+    open val diagnoses: List<DiagnosisResult>, // Results of diagnostic checks run, if any, if the job failed.
+    open val timestamp: String? = null, // Time the event occurred.
     override val type: String = "JobEvent"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -33,4 +33,3 @@ open class JobEvent (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/JobEvent.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/JobEvent.kt
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Represents a job event object. This can either be a state change or a progress update.
+ */
+open class JobEvent (
+    open val messageCommandOutput: String? = null,//Command output associated with the event, if applicable.
+    open val messageDetails: String? = null,//Localized message details.
+    open val messageAction: String? = null,//Localized message action.
+    open val messageCode: String? = null,//Message ID associated with the event.
+    open val eventType: String? = null,//Type of event.
+    open val percentComplete: Int? = null,//Completion percentage.
+    open val state: String? = null,//New state of the job.
+    open val diagnoses: List<DiagnosisResult>,//Results of diagnostic checks run, if any, if the job failed.
+    open val timestamp: String? = null,//Time the event occurred.
+    override val type: String = "JobEvent"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "messageCommandOutput" to messageCommandOutput,
+            "messageDetails" to messageDetails,
+            "messageAction" to messageAction,
+            "messageCode" to messageCode,
+            "eventType" to eventType,
+            "percentComplete" to percentComplete,
+            "state" to state,
+            "diagnoses" to diagnoses,
+            "timestamp" to timestamp,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Json.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Json.kt
@@ -16,6 +16,6 @@ package com.delphix.sdk.objects
  * A dummy schema that is used to represent JSON.
  */
 interface Json {
-    val type: String //"Object type."
+    val type: String // "Object type."
     fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Json.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Json.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A dummy schema that is used to represent JSON.
+ */
+interface Json {
+    val type: String //"Object type."
+    fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/LoginRequest.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/LoginRequest.kt
@@ -6,10 +6,10 @@ package com.delphix.sdk.objects
 /**
  * Represents a Delphix user authentication request.
  */
-open class LoginRequest (
-    open val password: String? = null,//The password of the user to authenticate.
-    open val target: String? = null,//The authentication domain.
-    open val username: String? = null,//The username of the user to authenticate.
+open class LoginRequest(
+    open val password: String? = null, // The password of the user to authenticate.
+    open val target: String? = null, // The authentication domain.
+    open val username: String? = null, // The username of the user to authenticate.
     override val type: String = "LoginRequest"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -21,4 +21,3 @@ open class LoginRequest (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/LoginRequest.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/LoginRequest.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Represents a Delphix user authentication request.
+ */
+open class LoginRequest (
+    open val password: String? = null,//The password of the user to authenticate.
+    open val target: String? = null,//The authentication domain.
+    open val username: String? = null,//The username of the user to authenticate.
+    override val type: String = "LoginRequest"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "password" to password,
+            "target" to target,
+            "username" to username,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/NamedUserObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/NamedUserObject.kt
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Super schema for all schemas representing user-visible objects that have a name.
+ */
+interface NamedUserObject : UserObject {
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/NamedUserObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/NamedUserObject.kt
@@ -7,9 +7,9 @@ package com.delphix.sdk.objects
  * Super schema for all schemas representing user-visible objects that have a name.
  */
 interface NamedUserObject : UserObject {
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/OKResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/OKResult.kt
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Result of a successful API call.
+ */
+open class OKResult (
+    open val result: Any? = null,//Result of the operation. This will be specific to the API being invoked.
+    open val action: String? = null,//Reference to the action associated with the operation, if any.
+    open val job: String? = null,//Reference to the job started by the operation, if any.
+    override val status: String? = null,//Indicates whether an error occurred during the call.
+    override val type: String = "OKResult"
+) : CallResult {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "result" to result,
+            "action" to action,
+            "job" to job,
+            "status" to status,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/OKResult.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/OKResult.kt
@@ -6,11 +6,11 @@ package com.delphix.sdk.objects
 /**
  * Result of a successful API call.
  */
-open class OKResult (
-    open val result: Any? = null,//Result of the operation. This will be specific to the API being invoked.
-    open val action: String? = null,//Reference to the action associated with the operation, if any.
-    open val job: String? = null,//Reference to the job started by the operation, if any.
-    override val status: String? = null,//Indicates whether an error occurred during the call.
+open class OKResult(
+    open val result: Any? = null, // Result of the operation. This will be specific to the API being invoked.
+    open val action: String? = null, // Reference to the action associated with the operation, if any.
+    open val job: String? = null, // Reference to the job started by the operation, if any.
+    override val status: String? = null, // Indicates whether an error occurred during the call.
     override val type: String = "OKResult"
 ) : CallResult {
     override fun toMap(): Map<String, Any?> {
@@ -23,4 +23,3 @@ open class OKResult (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Operation.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Operation.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A user-specifiable operation that can be performed on sources.
+ */
+interface Operation : TypedObject {
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/OperationTemplate.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/OperationTemplate.kt
@@ -6,13 +6,13 @@ package com.delphix.sdk.objects
 /**
  * Template for commonly used operations.
  */
-open class OperationTemplate (
-    open val lastUpdated: String? = null,//Most recently modified time.
-    override val name: String? = null,//Object name.
-    open val description: String? = null,//User provided description for this template.
-    open val operation: SourceOperation? = null,//Template contents.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class OperationTemplate(
+    open val lastUpdated: String? = null, // Most recently modified time.
+    override val name: String? = null, // Object name.
+    open val description: String? = null, // User provided description for this template.
+    open val operation: SourceOperation? = null, // Template contents.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "OperationTemplate"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -27,4 +27,3 @@ open class OperationTemplate (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/OperationTemplate.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/OperationTemplate.kt
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Template for commonly used operations.
+ */
+open class OperationTemplate (
+    open val lastUpdated: String? = null,//Most recently modified time.
+    override val name: String? = null,//Object name.
+    open val description: String? = null,//User provided description for this template.
+    open val operation: SourceOperation? = null,//Template contents.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "OperationTemplate"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "lastUpdated" to lastUpdated,
+            "name" to name,
+            "description" to description,
+            "operation" to operation,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PasswordCredential.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PasswordCredential.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The password based security credential.
+ */
+open class PasswordCredential (
+    open val password: String? = null,//The password.
+    override val type: String = "PasswordCredential"
+) : Credential {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "password" to password,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PasswordCredential.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PasswordCredential.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * The password based security credential.
  */
-open class PasswordCredential (
-    open val password: String? = null,//The password.
+open class PasswordCredential(
+    open val password: String? = null, // The password.
     override val type: String = "PasswordCredential"
 ) : Credential {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class PasswordCredential (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PersistentObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PersistentObject.kt
@@ -7,8 +7,8 @@ package com.delphix.sdk.objects
  * Super schema for all typed schemas with a reference property.
  */
 interface PersistentObject : TypedObject {
-    val reference: String?//The object reference.
-    val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val reference: String? // The object reference.
+    val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PersistentObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PersistentObject.kt
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Super schema for all typed schemas with a reference property.
+ */
+interface PersistentObject : TypedObject {
+    val reference: String?//The object reference.
+    val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PreProvisioningRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PreProvisioningRuntime.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime properties for pre-provisioning of a MSSQL database container.
+ */
+open class PreProvisioningRuntime (
+    open val lastUpdateTimestamp: String? = null,//Timestamp of the last update to the status.
+    open val response: String? = null,//Response taken based on the status of the pre-provisioning run.
+    open val pendingAction: String? = null,//User action required to resolve any error that the pre-provisioning run encountered.
+    open val preProvisioningState: String? = null,//Indicates the current state of pre-provisioning for the database.
+    open val status: String? = null,//The status of the pre-provisioning run.
+    override val type: String = "PreProvisioningRuntime"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "lastUpdateTimestamp" to lastUpdateTimestamp,
+            "response" to response,
+            "pendingAction" to pendingAction,
+            "preProvisioningState" to preProvisioningState,
+            "status" to status,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PreProvisioningRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PreProvisioningRuntime.kt
@@ -6,12 +6,12 @@ package com.delphix.sdk.objects
 /**
  * Runtime properties for pre-provisioning of a MSSQL database container.
  */
-open class PreProvisioningRuntime (
-    open val lastUpdateTimestamp: String? = null,//Timestamp of the last update to the status.
-    open val response: String? = null,//Response taken based on the status of the pre-provisioning run.
-    open val pendingAction: String? = null,//User action required to resolve any error that the pre-provisioning run encountered.
-    open val preProvisioningState: String? = null,//Indicates the current state of pre-provisioning for the database.
-    open val status: String? = null,//The status of the pre-provisioning run.
+open class PreProvisioningRuntime(
+    open val lastUpdateTimestamp: String? = null, // Timestamp of the last update to the status.
+    open val response: String? = null, // Response taken based on the status of the pre-provisioning run.
+    open val pendingAction: String? = null, // User action required to resolve any error that the pre-provisioning run encountered.
+    open val preProvisioningState: String? = null, // Indicates the current state of pre-provisioning for the database.
+    open val status: String? = null, // The status of the pre-provisioning run.
     override val type: String = "PreProvisioningRuntime"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -25,4 +25,3 @@ open class PreProvisioningRuntime (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ProvisionParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ProvisionParameters.kt
@@ -7,11 +7,11 @@ package com.delphix.sdk.objects
  * The parameters to use as input when creating a new virtual dataset by provisioning.
  */
 interface ProvisionParameters : VirtualDatasetCreationParameters {
-    val timeflowPointParameters: TimeflowPointParameters?//The TimeFlow point, bookmark, or semantic location to base provisioning on.
-    val maskingJob: String?//The Masking Job to be run when this dataset is provisioned or refreshed.
-    override val container: Container?//The new container for the created dataset.
-    override val sourceConfig: SourceConfig?//The source config including dynamically discovered attributes of the source.
-    override val source: Source?//The source that describes an external dataset instance.
+    val timeflowPointParameters: TimeflowPointParameters? // The TimeFlow point, bookmark, or semantic location to base provisioning on.
+    val maskingJob: String? // The Masking Job to be run when this dataset is provisioned or refreshed.
+    override val container: Container? // The new container for the created dataset.
+    override val sourceConfig: SourceConfig? // The source config including dynamically discovered attributes of the source.
+    override val source: Source? // The source that describes an external dataset instance.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ProvisionParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ProvisionParameters.kt
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input when creating a new virtual dataset by provisioning.
+ */
+interface ProvisionParameters : VirtualDatasetCreationParameters {
+    val timeflowPointParameters: TimeflowPointParameters?//The TimeFlow point, bookmark, or semantic location to base provisioning on.
+    val maskingJob: String?//The Masking Job to be run when this dataset is provisioned or refreshed.
+    override val container: Container?//The new container for the created dataset.
+    override val sourceConfig: SourceConfig?//The source config including dynamically discovered attributes of the source.
+    override val source: Source?//The source that describes an external dataset instance.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/PublicKeyCredential.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/PublicKeyCredential.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The public key based security credential.
+ */
+interface PublicKeyCredential : Credential {
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ReadonlyNamedUserObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ReadonlyNamedUserObject.kt
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Super schema for all schemas representing user-visible objects that have a read-only &#39;name&#39;.
+ */
+interface ReadonlyNamedUserObject : UserObject {
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ReadonlyNamedUserObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ReadonlyNamedUserObject.kt
@@ -7,9 +7,9 @@ package com.delphix.sdk.objects
  * Super schema for all schemas representing user-visible objects that have a read-only &#39;name&#39;.
  */
 interface ReadonlyNamedUserObject : UserObject {
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Repository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Repository.kt
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.objects
+
+import org.json.JSONObject
+
+data class Repository(
+    val type: String,
+    val reference: String,
+    val name: String,
+    val environment: String,
+    val linkingEnabled: Boolean,
+    val parameters: String = "",
+    val provisioningEnabled: Boolean,
+    val staging: Boolean,
+    val toolkit: String = "",
+    val version: String
+){
+    companion object {
+        @JvmStatic
+        fun fromJson(node: JSONObject): Repository {
+            val repository = Repository(
+                node.get("type").toString(),
+                node.get("reference").toString(),
+                node.get("name").toString(),
+                node.get("environment").toString(),
+                node.getBoolean("linkingEnabled"),
+                node.optString("parameters"),
+                node.getBoolean("provisioningEnabled"),
+                node.getBoolean("staging"),
+                node.optString("toolkit"),
+                node.get("version").toString()
+            )
+            return repository
+        }
+    }
+}
+
+/*
+{
+"provisioningEnabled":true,
+"discovered":true,
+"segmentSize":16777216,
+"bits":64,
+"type":"PgSQLInstall",
+"version":"9.6.11",
+"reference":"PGSQL_INSTALL-2",
+"environment":"UNIX_HOST_ENVIRONMENT-4",
+"namespace":null,
+"name":"/usr/pgsql-9.6",
+"variant":"PostgreSQL",
+"installationPath":"/usr/pgsql-9.6",
+"linkingEnabled":true,
+"staging":false
+}
+*/

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Repository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Repository.kt
@@ -17,7 +17,7 @@ data class Repository(
     val staging: Boolean,
     val toolkit: String = "",
     val version: String
-){
+) {
     companion object {
         @JvmStatic
         fun fromJson(node: JSONObject): Repository {

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SchemaDraftV4.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SchemaDraftV4.kt
@@ -16,6 +16,6 @@ package com.delphix.sdk.objects
  * A dummy schema that is used to represent JSON that is a valid Draft v4 schema.
  */
 interface SchemaDraftV4 {
-    val type: String //"Object type."
+    val type: String // "Object type."
     fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SchemaDraftV4.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SchemaDraftV4.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A dummy schema that is used to represent JSON that is a valid Draft v4 schema.
+ */
+interface SchemaDraftV4 {
+    val type: String //"Object type."
+    fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SnapshotRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SnapshotRuntime.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * Runtime properties of a TimeFlow snapshot.
  */
-open class SnapshotRuntime (
-    open val provisionable: Boolean? = null,//True if this snapshot can be used as the basis for provisioning a new TimeFlow.
+open class SnapshotRuntime(
+    open val provisionable: Boolean? = null, // True if this snapshot can be used as the basis for provisioning a new TimeFlow.
     override val type: String = "SnapshotRuntime"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class SnapshotRuntime (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SnapshotRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SnapshotRuntime.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime properties of a TimeFlow snapshot.
+ */
+open class SnapshotRuntime (
+    open val provisionable: Boolean? = null,//True if this snapshot can be used as the basis for provisioning a new TimeFlow.
+    override val type: String = "SnapshotRuntime"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "provisionable" to provisionable,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Source.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Source.kt
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A source represents an external database instance outside the Delphix system.
+ */
+interface Source : UserObject {
+    val container: String?//Reference to the container being fed by this source, if any.
+    val virtual: Boolean?//Flag indicating whether the source is a virtual source in the Delphix system.
+    val description: String?//A user-provided description of the source.
+    val runtime: SourceRuntime?//Runtime properties of this source.
+    val config: String?//Reference to the configuration for the source.
+    val staging: Boolean?//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    val restoration: Boolean?//Flag indicating whether the source is a restoration source in the Delphix system.
+    val linked: Boolean?//Flag indicating whether the source is a linked source in the Delphix system.
+    val status: String?//Status of this source.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Source.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Source.kt
@@ -7,18 +7,18 @@ package com.delphix.sdk.objects
  * A source represents an external database instance outside the Delphix system.
  */
 interface Source : UserObject {
-    val container: String?//Reference to the container being fed by this source, if any.
-    val virtual: Boolean?//Flag indicating whether the source is a virtual source in the Delphix system.
-    val description: String?//A user-provided description of the source.
-    val runtime: SourceRuntime?//Runtime properties of this source.
-    val config: String?//Reference to the configuration for the source.
-    val staging: Boolean?//Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
-    val restoration: Boolean?//Flag indicating whether the source is a restoration source in the Delphix system.
-    val linked: Boolean?//Flag indicating whether the source is a linked source in the Delphix system.
-    val status: String?//Status of this source.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val container: String? // Reference to the container being fed by this source, if any.
+    val virtual: Boolean? // Flag indicating whether the source is a virtual source in the Delphix system.
+    val description: String? // A user-provided description of the source.
+    val runtime: SourceRuntime? // Runtime properties of this source.
+    val config: String? // Reference to the configuration for the source.
+    val staging: Boolean? // Flag indicating whether the source is used as a staging source for pre-provisioning. Staging sources are managed by the Delphix system.
+    val restoration: Boolean? // Flag indicating whether the source is a restoration source in the Delphix system.
+    val linked: Boolean? // Flag indicating whether the source is a linked source in the Delphix system.
+    val status: String? // Status of this source.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConfig.kt
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The source config represents the dynamically discovered attributes of a source.
+ */
+interface SourceConfig : ReadonlyNamedUserObject {
+    val discovered: Boolean?//Whether this source was discovered.
+    val environmentUser: String?//The user used to create and manage the configuration.
+    val linkingEnabled: Boolean?//Whether this source should be used for linking.
+    val repository: String?//The object reference of the source repository.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConfig.kt
@@ -7,13 +7,13 @@ package com.delphix.sdk.objects
  * The source config represents the dynamically discovered attributes of a source.
  */
 interface SourceConfig : ReadonlyNamedUserObject {
-    val discovered: Boolean?//Whether this source was discovered.
-    val environmentUser: String?//The user used to create and manage the configuration.
-    val linkingEnabled: Boolean?//Whether this source should be used for linking.
-    val repository: String?//The object reference of the source repository.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val discovered: Boolean? // Whether this source was discovered.
+    val environmentUser: String? // The user used to create and manage the configuration.
+    val linkingEnabled: Boolean? // Whether this source should be used for linking.
+    val repository: String? // The object reference of the source repository.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConnectionInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConnectionInfo.kt
@@ -7,7 +7,7 @@ package com.delphix.sdk.objects
  * Contains information that can be used to connect to the source.
  */
 interface SourceConnectionInfo : TypedObject {
-    val version: String?//The database version string.
+    val version: String? // The database version string.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConnectionInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceConnectionInfo.kt
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Contains information that can be used to connect to the source.
+ */
+interface SourceConnectionInfo : TypedObject {
+    val version: String?//The database version string.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceDisableParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceDisableParameters.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input to disable a MSSQL, PostgreSQL, AppData, ASE or MySQL source.
  */
-open class SourceDisableParameters (
-    open val attemptCleanup: Boolean? = null,//Whether to attempt a cleanup of the database from the environment before the disable.
+open class SourceDisableParameters(
+    open val attemptCleanup: Boolean? = null, // Whether to attempt a cleanup of the database from the environment before the disable.
     override val type: String = "SourceDisableParameters"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class SourceDisableParameters (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceDisableParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceDisableParameters.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input to disable a MSSQL, PostgreSQL, AppData, ASE or MySQL source.
+ */
+open class SourceDisableParameters (
+    open val attemptCleanup: Boolean? = null,//Whether to attempt a cleanup of the database from the environment before the disable.
+    override val type: String = "SourceDisableParameters"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "attemptCleanup" to attemptCleanup,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironment.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The generic source environment schema.
+ */
+interface SourceEnvironment : UserObject {
+    val primaryUser: String?//A reference to the primary user for this environment.
+    val description: String?//The environment description.
+    val enabled: Boolean?//Indicates whether the source environment is enabled.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironment.kt
@@ -7,12 +7,12 @@ package com.delphix.sdk.objects
  * The generic source environment schema.
  */
 interface SourceEnvironment : UserObject {
-    val primaryUser: String?//A reference to the primary user for this environment.
-    val description: String?//The environment description.
-    val enabled: Boolean?//Indicates whether the source environment is enabled.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val primaryUser: String? // A reference to the primary user for this environment.
+    val description: String? // The environment description.
+    val enabled: Boolean? // Indicates whether the source environment is enabled.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironmentCreateParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironmentCreateParameters.kt
@@ -7,7 +7,7 @@ package com.delphix.sdk.objects
  * The parameters used for source environment create parameters.
  */
 interface SourceEnvironmentCreateParameters : TypedObject {
-    val primaryUser: EnvironmentUser?//The primary user associated with the environment.
+    val primaryUser: EnvironmentUser? // The primary user associated with the environment.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironmentCreateParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceEnvironmentCreateParameters.kt
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters used for source environment create parameters.
+ */
+interface SourceEnvironmentCreateParameters : TypedObject {
+    val primaryUser: EnvironmentUser?//The primary user associated with the environment.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceOperation.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceOperation.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A user-specifiable operation that can be performed on sources.
+ */
+interface SourceOperation : Operation {
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepository.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A source repository represents a container for the source config.
+ */
+interface SourceRepository : ReadonlyNamedUserObject {
+    val environment: String?//Reference to the environment containing this repository.
+    val provisioningEnabled: Boolean?//Flag indicating whether the repository should be used for provisioning.
+    val linkingEnabled: Boolean?//Flag indicating whether the repository should be used for linking.
+    val staging: Boolean?//Flag indicating whether this repository can be used by the Delphix Engine for internal processing.
+    val version: String?//Version of the repository.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepository.kt
@@ -7,14 +7,14 @@ package com.delphix.sdk.objects
  * A source repository represents a container for the source config.
  */
 interface SourceRepository : ReadonlyNamedUserObject {
-    val environment: String?//Reference to the environment containing this repository.
-    val provisioningEnabled: Boolean?//Flag indicating whether the repository should be used for provisioning.
-    val linkingEnabled: Boolean?//Flag indicating whether the repository should be used for linking.
-    val staging: Boolean?//Flag indicating whether this repository can be used by the Delphix Engine for internal processing.
-    val version: String?//Version of the repository.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val environment: String? // Reference to the environment containing this repository.
+    val provisioningEnabled: Boolean? // Flag indicating whether the repository should be used for provisioning.
+    val linkingEnabled: Boolean? // Flag indicating whether the repository should be used for linking.
+    val staging: Boolean? // Flag indicating whether this repository can be used by the Delphix Engine for internal processing.
+    val version: String? // Version of the repository.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepositoryTemplate.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepositoryTemplate.kt
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The representation of a repository template object.
+ */
+open class SourceRepositoryTemplate (
+    open val container: String? = null,//The reference to the database container.
+    open val template: String? = null,//The reference to the associated template.
+    open val repository: String? = null,//The reference to the target repository.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "SourceRepositoryTemplate"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "container" to container,
+            "template" to template,
+            "repository" to repository,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepositoryTemplate.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRepositoryTemplate.kt
@@ -6,13 +6,13 @@ package com.delphix.sdk.objects
 /**
  * The representation of a repository template object.
  */
-open class SourceRepositoryTemplate (
-    open val container: String? = null,//The reference to the database container.
-    open val template: String? = null,//The reference to the associated template.
-    open val repository: String? = null,//The reference to the target repository.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class SourceRepositoryTemplate(
+    open val container: String? = null, // The reference to the database container.
+    open val template: String? = null, // The reference to the associated template.
+    open val repository: String? = null, // The reference to the target repository.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "SourceRepositoryTemplate"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -27,4 +27,3 @@ open class SourceRepositoryTemplate (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRuntime.kt
@@ -7,11 +7,11 @@ package com.delphix.sdk.objects
  * Runtime properties of a linked or virtual source database.
  */
 interface SourceRuntime : TypedObject {
-    val accessible: Boolean?//True if the source is JDBC accessible. If false then no properties can be retrieved.
-    val databaseSize: Int?//Size of the database in bytes.
-    val enabled: String?//Status indicating whether the source is enabled. A source has a 'PARTIAL' status if its sub-sources are not all enabled.
-    val notAccessibleReason: String?//The reason why the source is not JDBC accessible.
-    val status: String?//Status of the source. 'Unknown' if all attempts to connect to the source failed.
+    val accessible: Boolean? // True if the source is JDBC accessible. If false then no properties can be retrieved.
+    val databaseSize: Int? // Size of the database in bytes.
+    val enabled: String? // Status indicating whether the source is enabled. A source has a 'PARTIAL' status if its sub-sources are not all enabled.
+    val notAccessibleReason: String? // The reason why the source is not JDBC accessible.
+    val status: String? // Status of the source. 'Unknown' if all attempts to connect to the source failed.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRuntime.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourceRuntime.kt
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Runtime properties of a linked or virtual source database.
+ */
+interface SourceRuntime : TypedObject {
+    val accessible: Boolean?//True if the source is JDBC accessible. If false then no properties can be retrieved.
+    val databaseSize: Int?//Size of the database in bytes.
+    val enabled: String?//Status indicating whether the source is enabled. A source has a 'PARTIAL' status if its sub-sources are not all enabled.
+    val notAccessibleReason: String?//The reason why the source is not JDBC accessible.
+    val status: String?//Status of the source. 'Unknown' if all attempts to connect to the source failed.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourcingPolicy.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourcingPolicy.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * Database policies for managing SnapSync and LogSync across sources for a MSSQL container.
  */
-open class SourcingPolicy (
-    open val loadFromBackup: Boolean? = null,//True if the initial load and subsequent syncs for this container restore from already existing database backups. In such cases Delphix does not take any full database backups of the source database. When false, Delphix will take a full backup of the source.
-    open val logsyncEnabled: Boolean? = null,//True if LogSync should run for this database.
+open class SourcingPolicy(
+    open val loadFromBackup: Boolean? = null, // True if the initial load and subsequent syncs for this container restore from already existing database backups. In such cases Delphix does not take any full database backups of the source database. When false, Delphix will take a full backup of the source.
+    open val logsyncEnabled: Boolean? = null, // True if LogSync should run for this database.
     override val type: String = "SourcingPolicy"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class SourcingPolicy (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SourcingPolicy.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SourcingPolicy.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Database policies for managing SnapSync and LogSync across sources for a MSSQL container.
+ */
+open class SourcingPolicy (
+    open val loadFromBackup: Boolean? = null,//True if the initial load and subsequent syncs for this container restore from already existing database backups. In such cases Delphix does not take any full database backups of the source database. When false, Delphix will take a full backup of the source.
+    open val logsyncEnabled: Boolean? = null,//True if LogSync should run for this database.
+    override val type: String = "SourcingPolicy"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "loadFromBackup" to loadFromBackup,
+            "logsyncEnabled" to logsyncEnabled,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SyncParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SyncParameters.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input to sync requests.
+ */
+open class SyncParameters (
+    override val type: String = "SyncParameters"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SyncParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SyncParameters.kt
@@ -6,7 +6,7 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input to sync requests.
  */
-open class SyncParameters (
+open class SyncParameters(
     override val type: String = "SyncParameters"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -15,4 +15,3 @@ open class SyncParameters (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SystemKeyCredential.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SystemKeyCredential.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The system public key based security credential.
+ */
+open class SystemKeyCredential (
+    override val type: String = "SystemKeyCredential"
+) : PublicKeyCredential {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/SystemKeyCredential.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/SystemKeyCredential.kt
@@ -6,7 +6,7 @@ package com.delphix.sdk.objects
 /**
  * The system public key based security credential.
  */
-open class SystemKeyCredential (
+open class SystemKeyCredential(
     override val type: String = "SystemKeyCredential"
 ) : PublicKeyCredential {
     override fun toMap(): Map<String, Any?> {
@@ -15,4 +15,3 @@ open class SystemKeyCredential (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeRangeParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeRangeParameters.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input for methods requiring a time range.
+ */
+open class TimeRangeParameters (
+    open val startTime: String? = null,//The date at the beginning of the period.
+    open val endTime: String? = null,//The date at the end of the period.
+    override val type: String = "TimeRangeParameters"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "startTime" to startTime,
+            "endTime" to endTime,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeRangeParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeRangeParameters.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input for methods requiring a time range.
  */
-open class TimeRangeParameters (
-    open val startTime: String? = null,//The date at the beginning of the period.
-    open val endTime: String? = null,//The date at the end of the period.
+open class TimeRangeParameters(
+    open val startTime: String? = null, // The date at the beginning of the period.
+    open val endTime: String? = null, // The date at the end of the period.
     override val type: String = "TimeRangeParameters"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class TimeRangeParameters (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Timeflow.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Timeflow.kt
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Data for a particular historical timeline within a database.
+ */
+interface Timeflow : NamedUserObject {
+    val container: String?//Reference to the data container (database) for this TimeFlow.
+    val creationType: String?//The source action that created the TimeFlow.
+    val parentSnapshot: String?//Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
+    val parentPoint: TimeflowPoint?//The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/Timeflow.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/Timeflow.kt
@@ -7,13 +7,13 @@ package com.delphix.sdk.objects
  * Data for a particular historical timeline within a database.
  */
 interface Timeflow : NamedUserObject {
-    val container: String?//Reference to the data container (database) for this TimeFlow.
-    val creationType: String?//The source action that created the TimeFlow.
-    val parentSnapshot: String?//Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
-    val parentPoint: TimeflowPoint?//The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val container: String? // Reference to the data container (database) for this TimeFlow.
+    val creationType: String? // The source action that created the TimeFlow.
+    val parentSnapshot: String? // Reference to the parent snapshot that serves as the provisioning base for this object. This may be different from the snapshot within the parent point, and is only present for virtual TimeFlows.
+    val parentPoint: TimeflowPoint? // The origin point on the parent TimeFlow from which this TimeFlow was provisioned. This will not be present for TimeFlows derived from linked sources.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmark.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmark.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A TimeFlow bookmark is a user defined name for a TimeFlow point (location or timestamp within a TimeFlow).
+ */
+open class TimeflowBookmark (
+    open val retentionProof: Boolean? = null,//Indicates whether retention should be allowed to clean up the TimeFlow bookmark and associated data.
+    open val location: String? = null,//The TimeFlow location.
+    open val tag: String? = null,//A tag for the bookmark that can be used to group TimeFlow bookmarks together or qualify the type of the bookmark.
+    open val timeflow: String? = null,//Reference to the TimeFlow for this bookmark.
+    open val timestamp: String? = null,//The logical time corresponding to the TimeFlow location.
+    override val name: String? = null,//Object name.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "TimeflowBookmark"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "retentionProof" to retentionProof,
+            "location" to location,
+            "tag" to tag,
+            "timeflow" to timeflow,
+            "timestamp" to timestamp,
+            "name" to name,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmark.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmark.kt
@@ -6,15 +6,15 @@ package com.delphix.sdk.objects
 /**
  * A TimeFlow bookmark is a user defined name for a TimeFlow point (location or timestamp within a TimeFlow).
  */
-open class TimeflowBookmark (
-    open val retentionProof: Boolean? = null,//Indicates whether retention should be allowed to clean up the TimeFlow bookmark and associated data.
-    open val location: String? = null,//The TimeFlow location.
-    open val tag: String? = null,//A tag for the bookmark that can be used to group TimeFlow bookmarks together or qualify the type of the bookmark.
-    open val timeflow: String? = null,//Reference to the TimeFlow for this bookmark.
-    open val timestamp: String? = null,//The logical time corresponding to the TimeFlow location.
-    override val name: String? = null,//Object name.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class TimeflowBookmark(
+    open val retentionProof: Boolean? = null, // Indicates whether retention should be allowed to clean up the TimeFlow bookmark and associated data.
+    open val location: String? = null, // The TimeFlow location.
+    open val tag: String? = null, // A tag for the bookmark that can be used to group TimeFlow bookmarks together or qualify the type of the bookmark.
+    open val timeflow: String? = null, // Reference to the TimeFlow for this bookmark.
+    open val timestamp: String? = null, // The logical time corresponding to the TimeFlow location.
+    override val name: String? = null, // Object name.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "TimeflowBookmark"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -31,4 +31,3 @@ open class TimeflowBookmark (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmarkCreateParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmarkCreateParameters.kt
@@ -6,11 +6,11 @@ package com.delphix.sdk.objects
 /**
  * The parameters to use as input to create TimeFlow bookmarks.
  */
-open class TimeflowBookmarkCreateParameters (
-    open val retentionProof: Boolean? = null,//Indicates whether retention should be allowed to clean up the TimeFlow bookmark and associated data.
-    open val name: String? = null,//The bookmark name.
-    open val tag: String? = null,//A tag for the bookmark that can be used to group bookmarks together or qualify the type of the bookmark.
-    open val timeflowPoint: TimeflowPoint? = null,//The TimeFlow point which is referenced by this bookmark.
+open class TimeflowBookmarkCreateParameters(
+    open val retentionProof: Boolean? = null, // Indicates whether retention should be allowed to clean up the TimeFlow bookmark and associated data.
+    open val name: String? = null, // The bookmark name.
+    open val tag: String? = null, // A tag for the bookmark that can be used to group bookmarks together or qualify the type of the bookmark.
+    open val timeflowPoint: TimeflowPoint? = null, // The TimeFlow point which is referenced by this bookmark.
     override val type: String = "TimeflowBookmarkCreateParameters"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -23,4 +23,3 @@ open class TimeflowBookmarkCreateParameters (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmarkCreateParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowBookmarkCreateParameters.kt
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input to create TimeFlow bookmarks.
+ */
+open class TimeflowBookmarkCreateParameters (
+    open val retentionProof: Boolean? = null,//Indicates whether retention should be allowed to clean up the TimeFlow bookmark and associated data.
+    open val name: String? = null,//The bookmark name.
+    open val tag: String? = null,//A tag for the bookmark that can be used to group bookmarks together or qualify the type of the bookmark.
+    open val timeflowPoint: TimeflowPoint? = null,//The TimeFlow point which is referenced by this bookmark.
+    override val type: String = "TimeflowBookmarkCreateParameters"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "retentionProof" to retentionProof,
+            "name" to name,
+            "tag" to tag,
+            "timeflowPoint" to timeflowPoint,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPoint.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPoint.kt
@@ -7,9 +7,9 @@ package com.delphix.sdk.objects
  * TimeFlow points represent a unique point within a TimeFlow.
  */
 interface TimeflowPoint : TypedObject {
-    val location: String?//The TimeFlow location.
-    val timeflow: String?//Reference to TimeFlow containing this point.
-    val timestamp: String?//The logical time corresponding to the TimeFlow location.
+    val location: String? // The TimeFlow location.
+    val timeflow: String? // Reference to TimeFlow containing this point.
+    val timestamp: String? // The logical time corresponding to the TimeFlow location.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPoint.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPoint.kt
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow points represent a unique point within a TimeFlow.
+ */
+interface TimeflowPoint : TypedObject {
+    val location: String?//The TimeFlow location.
+    val timeflow: String?//Reference to TimeFlow containing this point.
+    val timestamp: String?//The logical time corresponding to the TimeFlow location.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointLocation.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointLocation.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow point based on a database-specific identifier (SCN, LSN, etc).
+ */
+open class TimeflowPointLocation (
+    open val location: String? = null,//The TimeFlow location.
+    open val timeflow: String? = null,//Reference to TimeFlow containing this location.
+    override val type: String = "TimeflowPointLocation"
+) : TimeflowPointParameters {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "location" to location,
+            "timeflow" to timeflow,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointLocation.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointLocation.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * TimeFlow point based on a database-specific identifier (SCN, LSN, etc).
  */
-open class TimeflowPointLocation (
-    open val location: String? = null,//The TimeFlow location.
-    open val timeflow: String? = null,//Reference to TimeFlow containing this location.
+open class TimeflowPointLocation(
+    open val location: String? = null, // The TimeFlow location.
+    open val timeflow: String? = null, // Reference to TimeFlow containing this location.
     override val type: String = "TimeflowPointLocation"
 ) : TimeflowPointParameters {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class TimeflowPointLocation (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointParameters.kt
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Parameters indicating a TimeFlow point to use as input to database operations.
+ */
+interface TimeflowPointParameters : TypedObject {
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSemantic.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSemantic.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * TimeFlow point based on a semantic reference.
  */
-open class TimeflowPointSemantic (
-    open val container: String? = null,//Reference to the container.
-    open val location: String? = null,//A semantic description of a TimeFlow location.
+open class TimeflowPointSemantic(
+    open val container: String? = null, // Reference to the container.
+    open val location: String? = null, // A semantic description of a TimeFlow location.
     override val type: String = "TimeflowPointSemantic"
 ) : TimeflowPointParameters {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class TimeflowPointSemantic (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSemantic.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSemantic.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow point based on a semantic reference.
+ */
+open class TimeflowPointSemantic (
+    open val container: String? = null,//Reference to the container.
+    open val location: String? = null,//A semantic description of a TimeFlow location.
+    override val type: String = "TimeflowPointSemantic"
+) : TimeflowPointParameters {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "container" to container,
+            "location" to location,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSnapshot.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow point based on a snapshot reference.
+ */
+open class TimeflowPointSnapshot (
+    open val snapshot: String? = null,//Reference to the snapshot.
+    override val type: String = "TimeflowPointSnapshot"
+) : TimeflowPointParameters {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "snapshot" to snapshot,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointSnapshot.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * TimeFlow point based on a snapshot reference.
  */
-open class TimeflowPointSnapshot (
-    open val snapshot: String? = null,//Reference to the snapshot.
+open class TimeflowPointSnapshot(
+    open val snapshot: String? = null, // Reference to the snapshot.
     override val type: String = "TimeflowPointSnapshot"
 ) : TimeflowPointParameters {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class TimeflowPointSnapshot (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointTimestamp.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointTimestamp.kt
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * TimeFlow point based on a timestamp.
+ */
+open class TimeflowPointTimestamp (
+    open val timeflow: String? = null,//Reference to TimeFlow containing this point.
+    open val timestamp: String? = null,//The logical time corresponding to the TimeFlow location.
+    override val type: String = "TimeflowPointTimestamp"
+) : TimeflowPointParameters {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "timeflow" to timeflow,
+            "timestamp" to timestamp,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointTimestamp.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowPointTimestamp.kt
@@ -6,9 +6,9 @@ package com.delphix.sdk.objects
 /**
  * TimeFlow point based on a timestamp.
  */
-open class TimeflowPointTimestamp (
-    open val timeflow: String? = null,//Reference to TimeFlow containing this point.
-    open val timestamp: String? = null,//The logical time corresponding to the TimeFlow location.
+open class TimeflowPointTimestamp(
+    open val timeflow: String? = null, // Reference to TimeFlow containing this point.
+    open val timestamp: String? = null, // The logical time corresponding to the TimeFlow location.
     override val type: String = "TimeflowPointTimestamp"
 ) : TimeflowPointParameters {
     override fun toMap(): Map<String, Any?> {
@@ -19,4 +19,3 @@ open class TimeflowPointTimestamp (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowSnapshot.kt
@@ -7,21 +7,21 @@ package com.delphix.sdk.objects
  * Snapshot of a point within a TimeFlow that is used as the basis for provisioning.
  */
 interface TimeflowSnapshot : ReadonlyNamedUserObject {
-    val container: String?//Reference to the database of which this TimeFlow is a part.
-    val temporary: Boolean?//Boolean value indicating that this snapshot is in a transient state and should not be user visible.
-    val firstChangePoint: TimeflowPoint?//The location within the parent TimeFlow at which this snapshot was initiated. No recovery earlier than this point needs to be applied in order to provision a database from this snapshot. If "firstChangePoint" equals "latestChangePoint", then no recovery needs to be applied in order to provision a database.
-    val missingNonLoggedData: Boolean?//Boolean value indicating if a virtual database provisioned from this snapshot will be missing nologging changes.
-    val creationTime: String?//Point in time at which this snapshot was created. This may be different from the time corresponding to the TimeFlow.
-    val latestChangePoint: TimeflowPoint?//The location of the snapshot within the parent TimeFlow represented by this snapshot.
-    val timezone: String?//Time zone of the source database at the time the snapshot was taken.
-    val runtime: SnapshotRuntime?//Runtime properties of the snapshot.
-    val consistency: String?//A value in the set {CONSISTENT, INCONSISTENT, CRASH_CONSISTENT} indicating what type of recovery strategies must be invoked when provisioning from this snapshot.
-    val timeflow: String?//TimeFlow of which this snapshot is a part.
-    val version: String?//Version of database source repository at the time the snapshot was taken.
-    val retention: Int?//Retention policy, in days. A value of -1 indicates the snapshot should be kept forever.
-    override val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val container: String? // Reference to the database of which this TimeFlow is a part.
+    val temporary: Boolean? // Boolean value indicating that this snapshot is in a transient state and should not be user visible.
+    val firstChangePoint: TimeflowPoint? // The location within the parent TimeFlow at which this snapshot was initiated. No recovery earlier than this point needs to be applied in order to provision a database from this snapshot. If "firstChangePoint" equals "latestChangePoint", then no recovery needs to be applied in order to provision a database.
+    val missingNonLoggedData: Boolean? // Boolean value indicating if a virtual database provisioned from this snapshot will be missing nologging changes.
+    val creationTime: String? // Point in time at which this snapshot was created. This may be different from the time corresponding to the TimeFlow.
+    val latestChangePoint: TimeflowPoint? // The location of the snapshot within the parent TimeFlow represented by this snapshot.
+    val timezone: String? // Time zone of the source database at the time the snapshot was taken.
+    val runtime: SnapshotRuntime? // Runtime properties of the snapshot.
+    val consistency: String? // A value in the set {CONSISTENT, INCONSISTENT, CRASH_CONSISTENT} indicating what type of recovery strategies must be invoked when provisioning from this snapshot.
+    val timeflow: String? // TimeFlow of which this snapshot is a part.
+    val version: String? // Version of database source repository at the time the snapshot was taken.
+    val retention: Int? // Retention policy, in days. A value of -1 indicates the snapshot should be kept forever.
+    override val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TimeflowSnapshot.kt
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Snapshot of a point within a TimeFlow that is used as the basis for provisioning.
+ */
+interface TimeflowSnapshot : ReadonlyNamedUserObject {
+    val container: String?//Reference to the database of which this TimeFlow is a part.
+    val temporary: Boolean?//Boolean value indicating that this snapshot is in a transient state and should not be user visible.
+    val firstChangePoint: TimeflowPoint?//The location within the parent TimeFlow at which this snapshot was initiated. No recovery earlier than this point needs to be applied in order to provision a database from this snapshot. If "firstChangePoint" equals "latestChangePoint", then no recovery needs to be applied in order to provision a database.
+    val missingNonLoggedData: Boolean?//Boolean value indicating if a virtual database provisioned from this snapshot will be missing nologging changes.
+    val creationTime: String?//Point in time at which this snapshot was created. This may be different from the time corresponding to the TimeFlow.
+    val latestChangePoint: TimeflowPoint?//The location of the snapshot within the parent TimeFlow represented by this snapshot.
+    val timezone: String?//Time zone of the source database at the time the snapshot was taken.
+    val runtime: SnapshotRuntime?//Runtime properties of the snapshot.
+    val consistency: String?//A value in the set {CONSISTENT, INCONSISTENT, CRASH_CONSISTENT} indicating what type of recovery strategies must be invoked when provisioning from this snapshot.
+    val timeflow: String?//TimeFlow of which this snapshot is a part.
+    val version: String?//Version of database source repository at the time the snapshot was taken.
+    val retention: Int?//Retention policy, in days. A value of -1 indicates the snapshot should be kept forever.
+    override val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ToolkitVirtualSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ToolkitVirtualSource.kt
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * A virtual source definition for toolkits.
+ */
+open class ToolkitVirtualSource (
+    open val preSnapshot: String? = null,//A workflow script to run before taking a snapshot of a virtual copy of the application.
+    open val postSnapshot: String? = null,//A workflow script to run after taking a snapshot of a virtual copy of the application.
+    open val stop: String? = null,//A workflow script to run when stopping a virtual copy of the application.
+    open val start: String? = null,//A workflow script to run when starting a virtual copy of the application.
+    open val mountSpec: String? = null,//A workflow script that specifies where the virtual copy of the application should be mounted.
+    open val configure: String? = null,//A workflow script run when configuring a virtual copy of the application in a new environment.
+    open val initialize: String? = null,//A workflow script to run when creating an empty application.
+    open val unconfigure: String? = null,//A workflow script run when removing a virtual copy of the application from an environment (e.g. on delete, disable, or refresh).
+    open val parameters: SchemaDraftV4? = null,//A user defined schema for the provisioning parameters.
+    open val reconfigure: String? = null,//A workflow script run when returning a virtual copy of the appliction to an environment that it was previously removed from.
+    open val status: String? = null,//The workflow script to run to determine if a virtual copy of the application is running. The script should output 'ACTIVE' if the application is running, 'INACTIVE' if the application is not running, and 'UNKNOWN' if the script encounters an unexpected problem.
+    override val type: String = "ToolkitVirtualSource"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "preSnapshot" to preSnapshot,
+            "postSnapshot" to postSnapshot,
+            "stop" to stop,
+            "start" to start,
+            "mountSpec" to mountSpec,
+            "configure" to configure,
+            "initialize" to initialize,
+            "unconfigure" to unconfigure,
+            "parameters" to parameters,
+            "reconfigure" to reconfigure,
+            "status" to status,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/ToolkitVirtualSource.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/ToolkitVirtualSource.kt
@@ -6,18 +6,18 @@ package com.delphix.sdk.objects
 /**
  * A virtual source definition for toolkits.
  */
-open class ToolkitVirtualSource (
-    open val preSnapshot: String? = null,//A workflow script to run before taking a snapshot of a virtual copy of the application.
-    open val postSnapshot: String? = null,//A workflow script to run after taking a snapshot of a virtual copy of the application.
-    open val stop: String? = null,//A workflow script to run when stopping a virtual copy of the application.
-    open val start: String? = null,//A workflow script to run when starting a virtual copy of the application.
-    open val mountSpec: String? = null,//A workflow script that specifies where the virtual copy of the application should be mounted.
-    open val configure: String? = null,//A workflow script run when configuring a virtual copy of the application in a new environment.
-    open val initialize: String? = null,//A workflow script to run when creating an empty application.
-    open val unconfigure: String? = null,//A workflow script run when removing a virtual copy of the application from an environment (e.g. on delete, disable, or refresh).
-    open val parameters: SchemaDraftV4? = null,//A user defined schema for the provisioning parameters.
-    open val reconfigure: String? = null,//A workflow script run when returning a virtual copy of the appliction to an environment that it was previously removed from.
-    open val status: String? = null,//The workflow script to run to determine if a virtual copy of the application is running. The script should output 'ACTIVE' if the application is running, 'INACTIVE' if the application is not running, and 'UNKNOWN' if the script encounters an unexpected problem.
+open class ToolkitVirtualSource(
+    open val preSnapshot: String? = null, // A workflow script to run before taking a snapshot of a virtual copy of the application.
+    open val postSnapshot: String? = null, // A workflow script to run after taking a snapshot of a virtual copy of the application.
+    open val stop: String? = null, // A workflow script to run when stopping a virtual copy of the application.
+    open val start: String? = null, // A workflow script to run when starting a virtual copy of the application.
+    open val mountSpec: String? = null, // A workflow script that specifies where the virtual copy of the application should be mounted.
+    open val configure: String? = null, // A workflow script run when configuring a virtual copy of the application in a new environment.
+    open val initialize: String? = null, // A workflow script to run when creating an empty application.
+    open val unconfigure: String? = null, // A workflow script run when removing a virtual copy of the application from an environment (e.g. on delete, disable, or refresh).
+    open val parameters: SchemaDraftV4? = null, // A user defined schema for the provisioning parameters.
+    open val reconfigure: String? = null, // A workflow script run when returning a virtual copy of the appliction to an environment that it was previously removed from.
+    open val status: String? = null, // The workflow script to run to determine if a virtual copy of the application is running. The script should output 'ACTIVE' if the application is running, 'INACTIVE' if the application is not running, and 'UNKNOWN' if the script encounters an unexpected problem.
     override val type: String = "ToolkitVirtualSource"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -37,4 +37,3 @@ open class ToolkitVirtualSource (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TracerouteInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TracerouteInfo.kt
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Trace route info from target host to Delphix Engine.
+ */
+open class TracerouteInfo (
+    open val networkHops: String? = null,//Latency of network hops from host to Delphix Engine.
+    override val type: String = "TracerouteInfo"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "networkHops" to networkHops,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TracerouteInfo.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TracerouteInfo.kt
@@ -6,8 +6,8 @@ package com.delphix.sdk.objects
 /**
  * Trace route info from target host to Delphix Engine.
  */
-open class TracerouteInfo (
-    open val networkHops: String? = null,//Latency of network hops from host to Delphix Engine.
+open class TracerouteInfo(
+    open val networkHops: String? = null, // Latency of network hops from host to Delphix Engine.
     override val type: String = "TracerouteInfo"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -17,4 +17,3 @@ open class TracerouteInfo (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TypedObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TypedObject.kt
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Super schema for all other schemas.
+ */
+interface TypedObject {
+    val type: String //"Object type."
+    fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/TypedObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/TypedObject.kt
@@ -16,6 +16,6 @@ package com.delphix.sdk.objects
  * Super schema for all other schemas.
  */
 interface TypedObject {
-    val type: String //"Object type."
+    val type: String // "Object type."
     fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/User.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/User.kt
@@ -6,26 +6,26 @@ package com.delphix.sdk.objects
 /**
  * Delphix users.
  */
-open class User (
-    open val lastName: String? = null,//Last name of user.
-    open val mobilePhoneNumber: String? = null,//Mobile phone number of user.
-    open val homePhoneNumber: String? = null,//Home phone number of user.
-    open val publicKey: Any? = null,//Public key used for authentication.
-    open val locale: String? = null,//Preferred locale as an IETF BCP 47 language tag, defaults to 'en-US'.
-    open val passwordUpdateRequested: Boolean? = null,//True if the user's password should be updated.
-    open val enabled: Boolean? = null,//True if the user is currently enabled and can log into the system.
-    open val principal: String? = null,//Principal name used for authentication.
-    open val firstName: String? = null,//First name of user.
-    open val emailAddress: String? = null,//Email address for the user.
-    open val isDefault: Boolean? = null,//True if this is the default user and cannot be deleted.
-    open val credential: PasswordCredential? = null,//Credential used for authentication.
-    open val workPhoneNumber: String? = null,//Work phone number of user.
-    override val name: String? = null,//Object name.
-    open val sessionTimeout: Int? = null,//Session timeout in minutes.
-    open val authenticationType: String? = null,//User authentication type.
-    open val userType: String? = null,//Type of user.
-    override val reference: String? = null,//The object reference.
-    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+open class User(
+    open val lastName: String? = null, // Last name of user.
+    open val mobilePhoneNumber: String? = null, // Mobile phone number of user.
+    open val homePhoneNumber: String? = null, // Home phone number of user.
+    open val publicKey: Any? = null, // Public key used for authentication.
+    open val locale: String? = null, // Preferred locale as an IETF BCP 47 language tag, defaults to 'en-US'.
+    open val passwordUpdateRequested: Boolean? = null, // True if the user's password should be updated.
+    open val enabled: Boolean? = null, // True if the user is currently enabled and can log into the system.
+    open val principal: String? = null, // Principal name used for authentication.
+    open val firstName: String? = null, // First name of user.
+    open val emailAddress: String? = null, // Email address for the user.
+    open val isDefault: Boolean? = null, // True if this is the default user and cannot be deleted.
+    open val credential: PasswordCredential? = null, // Credential used for authentication.
+    open val workPhoneNumber: String? = null, // Work phone number of user.
+    override val name: String? = null, // Object name.
+    open val sessionTimeout: Int? = null, // Session timeout in minutes.
+    open val authenticationType: String? = null, // User authentication type.
+    open val userType: String? = null, // Type of user.
+    override val reference: String? = null, // The object reference.
+    override val namespace: String? = null, // Alternate namespace for this object, for replicated and restored objects.
     override val type: String = "User"
 ) : NamedUserObject {
     override fun toMap(): Map<String, Any?> {
@@ -53,4 +53,3 @@ open class User (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/User.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/User.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Delphix users.
+ */
+open class User (
+    open val lastName: String? = null,//Last name of user.
+    open val mobilePhoneNumber: String? = null,//Mobile phone number of user.
+    open val homePhoneNumber: String? = null,//Home phone number of user.
+    open val publicKey: Any? = null,//Public key used for authentication.
+    open val locale: String? = null,//Preferred locale as an IETF BCP 47 language tag, defaults to 'en-US'.
+    open val passwordUpdateRequested: Boolean? = null,//True if the user's password should be updated.
+    open val enabled: Boolean? = null,//True if the user is currently enabled and can log into the system.
+    open val principal: String? = null,//Principal name used for authentication.
+    open val firstName: String? = null,//First name of user.
+    open val emailAddress: String? = null,//Email address for the user.
+    open val isDefault: Boolean? = null,//True if this is the default user and cannot be deleted.
+    open val credential: PasswordCredential? = null,//Credential used for authentication.
+    open val workPhoneNumber: String? = null,//Work phone number of user.
+    override val name: String? = null,//Object name.
+    open val sessionTimeout: Int? = null,//Session timeout in minutes.
+    open val authenticationType: String? = null,//User authentication type.
+    open val userType: String? = null,//Type of user.
+    override val reference: String? = null,//The object reference.
+    override val namespace: String? = null,//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String = "User"
+) : NamedUserObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "lastName" to lastName,
+            "mobilePhoneNumber" to mobilePhoneNumber,
+            "homePhoneNumber" to homePhoneNumber,
+            "publicKey" to publicKey,
+            "locale" to locale,
+            "passwordUpdateRequested" to passwordUpdateRequested,
+            "enabled" to enabled,
+            "principal" to principal,
+            "firstName" to firstName,
+            "emailAddress" to emailAddress,
+            "isDefault" to isDefault,
+            "credential" to credential,
+            "workPhoneNumber" to workPhoneNumber,
+            "name" to name,
+            "sessionTimeout" to sessionTimeout,
+            "authenticationType" to authenticationType,
+            "userType" to userType,
+            "reference" to reference,
+            "namespace" to namespace,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/UserObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/UserObject.kt
@@ -7,9 +7,9 @@ package com.delphix.sdk.objects
  * Super schema for all schemas representing user-visible objects.
  */
 interface UserObject : PersistentObject {
-    val name: String?//Object name.
-    override val reference: String?//The object reference.
-    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    val name: String? // Object name.
+    override val reference: String? // The object reference.
+    override val namespace: String? // Alternate namespace for this object, for replicated and restored objects.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/UserObject.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/UserObject.kt
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Super schema for all schemas representing user-visible objects.
+ */
+interface UserObject : PersistentObject {
+    val name: String?//Object name.
+    override val reference: String?//The object reference.
+    override val namespace: String?//Alternate namespace for this object, for replicated and restored objects.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualDatasetCreationParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualDatasetCreationParameters.kt
@@ -7,9 +7,9 @@ package com.delphix.sdk.objects
  * The parameters to use as input when creating a new virtual dataset.
  */
 interface VirtualDatasetCreationParameters : TypedObject {
-    val container: Container?//The new container for the created dataset.
-    val sourceConfig: SourceConfig?//The source config including dynamically discovered attributes of the source.
-    val source: Source?//The source that describes an external dataset instance.
+    val container: Container? // The new container for the created dataset.
+    val sourceConfig: SourceConfig? // The source config including dynamically discovered attributes of the source.
+    val source: Source? // The source that describes an external dataset instance.
     override val type: String
     override fun toMap(): Map<String, Any?>
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualDatasetCreationParameters.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualDatasetCreationParameters.kt
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * The parameters to use as input when creating a new virtual dataset.
+ */
+interface VirtualDatasetCreationParameters : TypedObject {
+    val container: Container?//The new container for the created dataset.
+    val sourceConfig: SourceConfig?//The source config including dynamically discovered attributes of the source.
+    val source: Source?//The source that describes an external dataset instance.
+    override val type: String
+    override fun toMap(): Map<String, Any?>
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualSourceOperations.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualSourceOperations.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+package com.delphix.sdk.objects
+
+/**
+ * Describes operations which are performed on virtual sources at various times.
+ */
+open class VirtualSourceOperations (
+    open val preSnapshot: List<SourceOperation>,//Operations to perform before snapshotting a virtual source. These operations can quiesce any data prior to snapshotting.
+    open val postSnapshot: List<SourceOperation>,//Operations to perform after snapshotting a virtual source.
+    open val preRefresh: List<SourceOperation>,//Operations to perform before refreshing a virtual source. These operations can backup any data or configuration from the running source before doing the refresh.
+    open val postRollback: List<SourceOperation>,//Operations to perform after rewinding a virtual source. These operations can be used to automate processes once the rewind is complete.
+    open val preRollback: List<SourceOperation>,//Operations to perform before rewinding a virtual source. These operations can backup any data or configuration from the running source prior to rewinding.
+    open val configureClone: List<SourceOperation>,//Operations to perform when initially creating the virtual source and every time it is refreshed.
+    open val postRefresh: List<SourceOperation>,//Operations to perform after refreshing a virtual source. These operations can be used to restore any data or configuration backed up in the preRefresh operations.
+    override val type: String = "VirtualSourceOperations"
+) : TypedObject {
+    override fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "preSnapshot" to preSnapshot,
+            "postSnapshot" to postSnapshot,
+            "preRefresh" to preRefresh,
+            "postRollback" to postRollback,
+            "preRollback" to preRollback,
+            "configureClone" to configureClone,
+            "postRefresh" to postRefresh,
+            "type" to type
+        )
+    }
+}
+

--- a/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualSourceOperations.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/objects/VirtualSourceOperations.kt
@@ -6,14 +6,14 @@ package com.delphix.sdk.objects
 /**
  * Describes operations which are performed on virtual sources at various times.
  */
-open class VirtualSourceOperations (
-    open val preSnapshot: List<SourceOperation>,//Operations to perform before snapshotting a virtual source. These operations can quiesce any data prior to snapshotting.
-    open val postSnapshot: List<SourceOperation>,//Operations to perform after snapshotting a virtual source.
-    open val preRefresh: List<SourceOperation>,//Operations to perform before refreshing a virtual source. These operations can backup any data or configuration from the running source before doing the refresh.
-    open val postRollback: List<SourceOperation>,//Operations to perform after rewinding a virtual source. These operations can be used to automate processes once the rewind is complete.
-    open val preRollback: List<SourceOperation>,//Operations to perform before rewinding a virtual source. These operations can backup any data or configuration from the running source prior to rewinding.
-    open val configureClone: List<SourceOperation>,//Operations to perform when initially creating the virtual source and every time it is refreshed.
-    open val postRefresh: List<SourceOperation>,//Operations to perform after refreshing a virtual source. These operations can be used to restore any data or configuration backed up in the preRefresh operations.
+open class VirtualSourceOperations(
+    open val preSnapshot: List<SourceOperation>, // Operations to perform before snapshotting a virtual source. These operations can quiesce any data prior to snapshotting.
+    open val postSnapshot: List<SourceOperation>, // Operations to perform after snapshotting a virtual source.
+    open val preRefresh: List<SourceOperation>, // Operations to perform before refreshing a virtual source. These operations can backup any data or configuration from the running source before doing the refresh.
+    open val postRollback: List<SourceOperation>, // Operations to perform after rewinding a virtual source. These operations can be used to automate processes once the rewind is complete.
+    open val preRollback: List<SourceOperation>, // Operations to perform before rewinding a virtual source. These operations can backup any data or configuration from the running source prior to rewinding.
+    open val configureClone: List<SourceOperation>, // Operations to perform when initially creating the virtual source and every time it is refreshed.
+    open val postRefresh: List<SourceOperation>, // Operations to perform after refreshing a virtual source. These operations can be used to restore any data or configuration backed up in the preRefresh operations.
     override val type: String = "VirtualSourceOperations"
 ) : TypedObject {
     override fun toMap(): Map<String, Any?> {
@@ -29,4 +29,3 @@ open class VirtualSourceOperations (
         )
     }
 }
-

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/APISession.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/APISession.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * Describes a Delphix web service session and is the result of an initial handshake.
  */
-class APISession (
-        var http: Http
+class APISession(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/session"
 
@@ -28,5 +28,4 @@ class APISession (
     fun create(payload: com.delphix.sdk.objects.APISession): JSONObject {
         return http.handlePost("$root", payload.toMap())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/APISession.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/APISession.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * Describes a Delphix web service session and is the result of an initial handshake.
+ */
+class APISession (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/session"
+
+    /**
+     * Returns the settings of the current session, if one has been started.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Create a new APISession object.
+     */
+    fun create(payload: com.delphix.sdk.objects.APISession): JSONObject {
+        return http.handlePost("$root", payload.toMap())
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Action.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Action.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * Represents an action, a permanent record of activity on the server.
+ */
+class Action (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/action"
+
+    /**
+     * Retrieve an historical log of actions.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified Action object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Action.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Action.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * Represents an action, a permanent record of activity on the server.
  */
-class Action (
-        var http: Http
+class Action(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/action"
 
@@ -28,5 +28,4 @@ class Action (
     fun read(ref: String): JSONObject {
         return http.handleGet("$root/$ref")
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Container.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Container.kt
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http
+import org.json.JSONObject
+
+/**
+ * A container holding data.
+ */
+class Container (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/database"
+
+    /**
+     * Returns a list of databases on the system or within a group.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified Container object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Update the specified Container object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.Container): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Delete the specified Container object.
+     */
+    fun delete(ref: String, payload: com.delphix.sdk.objects.DeleteParameters): JSONObject {
+        return http.handlePost("$root/$ref/delete", payload.toMap())
+    }
+
+    /**
+     * Provisions the container specified by the provision parameters.
+     */
+    fun provision(ref: String, payload: com.delphix.sdk.objects.ProvisionParameters): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Performs SnapSync on a database.
+     */
+    fun sync(ref: String, payload: com.delphix.sdk.objects.SyncParameters): JSONObject {
+        return http.handlePost("$root/$ref/sync", payload.toMap())
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Container.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Container.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * A container holding data.
  */
-class Container (
-        var http: Http
+class Container(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/database"
 

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/EnvironmentUser.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/EnvironmentUser.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * The representation of an environment user object.
+ */
+class EnvironmentUser (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/environment/user"
+
+    /**
+     * Returns the list of all environment users in the system.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified EnvironmentUser object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Create a new EnvironmentUser object.
+     */
+    fun create(payload: com.delphix.sdk.objects.EnvironmentUser): JSONObject {
+        return http.handlePost("$root", payload.toMap())
+    }
+
+    /**
+     * Update the specified EnvironmentUser object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.EnvironmentUser): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Delete the specified EnvironmentUser object.
+     */
+    fun delete(ref: String): JSONObject {
+        return http.handlePost("$root/$ref", emptyMap<String, Any?>())
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/EnvironmentUser.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/EnvironmentUser.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * The representation of an environment user object.
  */
-class EnvironmentUser (
-        var http: Http
+class EnvironmentUser(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/environment/user"
 
@@ -49,5 +49,4 @@ class EnvironmentUser (
     fun delete(ref: String): JSONObject {
         return http.handlePost("$root/$ref", emptyMap<String, Any?>())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Group.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Group.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * Database group.
  */
-class Group (
-        var http: Http
+class Group(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/group"
 
@@ -49,5 +49,4 @@ class Group (
     fun delete(ref: String): JSONObject {
         return http.handlePost("$root/$ref", emptyMap<String, Any?>())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Group.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Group.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * Database group.
+ */
+class Group (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/group"
+
+    /**
+     * List Group objects on the system.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified Group object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Create a new Group object.
+     */
+    fun create(payload: com.delphix.sdk.objects.Group): JSONObject {
+        return http.handlePost("$root", payload.toMap())
+    }
+
+    /**
+     * Update the specified Group object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.Group): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Delete the specified Group object.
+     */
+    fun delete(ref: String): JSONObject {
+        return http.handlePost("$root/$ref", emptyMap<String, Any?>())
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Host.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Host.kt
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * The representation of a host object.
+ */
+class Host (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/host"
+
+    /**
+     * Returns the list of all hosts in the system.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified Host object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Update the specified Host object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.Host): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Host.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Host.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * The representation of a host object.
  */
-class Host (
-        var http: Http
+class Host(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/host"
 
@@ -35,5 +35,4 @@ class Host (
     fun update(ref: String, payload: com.delphix.sdk.objects.Host): JSONObject {
         return http.handlePost("$root/$ref", payload.toMap())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Job.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Job.kt
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * Represents a job object.
+ */
+class Job (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/job"
+
+    /**
+     * Returns a list of jobs in the system. Jobs are listed in start time order.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified Job object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Update the specified Job object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.Job): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Job.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Job.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * Represents a job object.
  */
-class Job (
-        var http: Http
+class Job(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/job"
 
@@ -35,5 +35,4 @@ class Job (
     fun update(ref: String, payload: com.delphix.sdk.objects.Job): JSONObject {
         return http.handlePost("$root/$ref", payload.toMap())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Repository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Repository.kt
@@ -6,9 +6,8 @@ package com.delphix.sdk.repos
 
 import com.delphix.sdk.Http as Http
 import com.delphix.sdk.objects.Repository as RepoObj
-import org.json.JSONObject
 
-class Repository (
+class Repository(
     var http: Http
 ) {
     val resource: String = "/resources/json/delphix/repository"
@@ -17,7 +16,7 @@ class Repository (
         var repositories = mutableListOf<RepoObj>()
         val response = http.handleGet(resource).getJSONArray("result")
         for (i in 0 until response.length()) {
-            val repository = response.getJSONObject(i);
+            val repository = response.getJSONObject(i)
             repositories.add(RepoObj.fromJson(repository))
         }
         return repositories
@@ -28,5 +27,4 @@ class Repository (
         val repository = RepoObj.fromJson(response.getJSONObject("result"))
         return repository
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Repository.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Repository.kt
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import com.delphix.sdk.objects.Repository as RepoObj
+import org.json.JSONObject
+
+class Repository (
+    var http: Http
+) {
+    val resource: String = "/resources/json/delphix/repository"
+
+    fun list(): List<RepoObj> {
+        var repositories = mutableListOf<RepoObj>()
+        val response = http.handleGet(resource).getJSONArray("result")
+        for (i in 0 until response.length()) {
+            val repository = response.getJSONObject(i);
+            repositories.add(RepoObj.fromJson(repository))
+        }
+        return repositories
+    }
+
+    fun get(ref: String): RepoObj {
+        val response = http.handleGet("$resource/$ref")
+        val repository = RepoObj.fromJson(response.getJSONObject("result"))
+        return repository
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Source.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Source.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * A source represents an external database instance outside the Delphix system.
  */
-class Source (
-        var http: Http
+class Source(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/source"
 

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/Source.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/Source.kt
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * A source represents an external database instance outside the Delphix system.
+ */
+class Source (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/source"
+
+    /**
+     * Lists sources on the system.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified Source object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Update the specified Source object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.Source): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Disables the given source.
+     */
+    fun disable(ref: String, payload: com.delphix.sdk.objects.SourceDisableParameters): JSONObject {
+        return http.handlePost("$root/$ref/disable", payload.toMap())
+    }
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/SourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/SourceConfig.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * The source config represents the dynamically discovered attributes of a source.
+ */
+class SourceConfig (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/sourceconfig"
+
+    /**
+     * Returns a list of source configs within the repository or the environment.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified SourceConfig object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Create a new SourceConfig object.
+     */
+    fun create(payload: com.delphix.sdk.objects.SourceConfig): JSONObject {
+        return http.handlePost("$root", payload.toMap())
+    }
+
+    /**
+     * Update the specified SourceConfig object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.SourceConfig): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Delete the specified SourceConfig object.
+     */
+    fun delete(ref: String): JSONObject {
+        return http.handlePost("$root/$ref", emptyMap<String, Any?>())
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/SourceConfig.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/SourceConfig.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * The source config represents the dynamically discovered attributes of a source.
  */
-class SourceConfig (
-        var http: Http
+class SourceConfig(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/sourceconfig"
 
@@ -49,5 +49,4 @@ class SourceConfig (
     fun delete(ref: String): JSONObject {
         return http.handlePost("$root/$ref", emptyMap<String, Any?>())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/SourceEnvironment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/SourceEnvironment.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * The generic source environment schema.
  */
-class SourceEnvironment (
-        var http: Http
+class SourceEnvironment(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/environment"
 
@@ -49,5 +49,4 @@ class SourceEnvironment (
     fun delete(ref: String): JSONObject {
         return http.handleDelete("$root/$ref")
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/SourceEnvironment.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/SourceEnvironment.kt
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * The generic source environment schema.
+ */
+class SourceEnvironment (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/environment"
+
+    /**
+     * Returns the list of all source environments.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified SourceEnvironment object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Create a new SourceEnvironment object.
+     */
+    fun create(payload: com.delphix.sdk.objects.SourceEnvironmentCreateParameters): JSONObject {
+        return http.handlePost("$root", payload.toMap())
+    }
+
+    /**
+     * Update the specified SourceEnvironment object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.SourceEnvironment): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Delete the specified SourceEnvironment object.
+     */
+    fun delete(ref: String): JSONObject {
+        return http.handleDelete("$root/$ref")
+    }
+
+}

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/TimeflowSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/TimeflowSnapshot.kt
@@ -10,8 +10,8 @@ import org.json.JSONObject
 /**
  * Snapshot of a point within a TimeFlow that is used as the basis for provisioning.
  */
-class TimeflowSnapshot (
-        var http: Http
+class TimeflowSnapshot(
+    var http: Http
 ) {
     val root: String = "/resources/json/delphix/snapshot"
 
@@ -42,5 +42,4 @@ class TimeflowSnapshot (
     fun delete(ref: String): JSONObject {
         return http.handlePost("$root/$ref", emptyMap<String, Any?>())
     }
-
 }

--- a/engine/src/main/kotlin/com/delphix/sdk/repos/TimeflowSnapshot.kt
+++ b/engine/src/main/kotlin/com/delphix/sdk/repos/TimeflowSnapshot.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2019 by Delphix. All rights reserved.
+ */
+
+package com.delphix.sdk.repos
+
+import com.delphix.sdk.Http as Http
+import org.json.JSONObject
+
+/**
+ * Snapshot of a point within a TimeFlow that is used as the basis for provisioning.
+ */
+class TimeflowSnapshot (
+        var http: Http
+) {
+    val root: String = "/resources/json/delphix/snapshot"
+
+    /**
+     * Returns a list of snapshots on the system or within a particular object. By default, all snapshots within the domain are listed.
+     */
+    fun list(): JSONObject {
+        return http.handleGet("$root")
+    }
+
+    /**
+     * Retrieve the specified TimeflowSnapshot object.
+     */
+    fun read(ref: String): JSONObject {
+        return http.handleGet("$root/$ref")
+    }
+
+    /**
+     * Update the specified TimeflowSnapshot object.
+     */
+    fun update(ref: String, payload: com.delphix.sdk.objects.TimeflowSnapshot): JSONObject {
+        return http.handlePost("$root/$ref", payload.toMap())
+    }
+
+    /**
+     * Delete the specified TimeflowSnapshot object.
+     */
+    fun delete(ref: String): JSONObject {
+        return http.handlePost("$root/$ref", emptyMap<String, Any?>())
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 rootProject.name = "delphix-remote"
 
 include("client")
+include("engine")


### PR DESCRIPTION
## Proposed Changes

This is a pure mechanical change to copy the engine SDK code from `titan-server` into the delphix remote. There is no new code added to the remote itself, it's just a lift-and-shift. The engine SDK will be removed from `titan-server` after all functionality has been ported over to the external remotes.

## Testing

`gradle build`