### PR TITLE
remote commits

### DIFF
--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm")
+    `maven-publish`
 }
 
 repositories {
@@ -9,7 +10,7 @@ repositories {
 }
 
 val jar by tasks.getting(Jar::class) {
-    archiveBaseName.set("engine-sdk")
+    archiveBaseName.set("delphix-sdk")
 }
 
 dependencies {
@@ -17,4 +18,31 @@ dependencies {
     compile(kotlin("reflect"))
     compile("org.json:json:20190722")
     compile("com.squareup.okhttp3:okhttp:4.2.2")
+}
+
+// Maven publishing configuration
+val mavenBucket = when(project.hasProperty("mavenBucket")) {
+    true -> project.property("mavenBucket")
+    false -> "titan-data-maven"
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "io.titandata"
+            artifactId = "delphix-sdk"
+
+            from(components["java"])
+        }
+    }
+
+    repositories {
+        maven {
+            name = "titan"
+            url = uri("s3://$mavenBucket")
+            authentication {
+                create<AwsImAuthentication>("awsIm")
+            }
+        }
+    }
 }

--- a/engine/build.gradle.kts
+++ b/engine/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("jvm")
-    `maven-publish`
 }
 
 repositories {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     compile(kotlin("stdlib"))
     compile("io.titandata:remote-sdk:0.0.8")
     compile("com.google.code.gson:gson:2.8.6")
+    compile(project(path = ":engine", configuration = "default"))
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")
     testImplementation("io.mockk:mockk:1.9.3")
 }

--- a/server/src/main/kotlin/io/titandata/remote/delphix/server/DelphixRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/delphix/server/DelphixRemoteServer.kt
@@ -1,8 +1,15 @@
 package io.titandata.remote.delphix.server
 
+import com.delphix.sdk.Delphix
+import com.delphix.sdk.Http
+import com.delphix.sdk.objects.Repository
 import io.titandata.remote.RemoteOperation
 import io.titandata.remote.RemoteServer
 import io.titandata.remote.RemoteServerUtil
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * The Delphix remote provider is a proof of concept implementation, dependent on a proprietary plugin that is not
@@ -11,6 +18,10 @@ import io.titandata.remote.RemoteServerUtil
 class DelphixRemoteServer : RemoteServer {
 
     internal val util = RemoteServerUtil()
+
+    companion object {
+        val log = LoggerFactory.getLogger(DelphixRemoteServer::class.java)
+    }
 
     override fun getProvider(): String {
         return "engine"
@@ -26,12 +37,113 @@ class DelphixRemoteServer : RemoteServer {
         return parameters
     }
 
+    private fun connect(remote: Map<String, Any>, params: Map<String, Any>): Delphix {
+        val engine = Delphix(Http("http://${remote["address"]}"))
+        if (remote["password"] == null && params["password"] == null) {
+            throw IllegalArgumentException("missing password in remote parameters")
+        }
+        engine.login(remote["username"] as String, (params["password"] ?: remote["password"]).toString())
+        return engine
+    }
+
+    private fun findInResult(result: JSONObject, lambda: (JSONObject) -> Boolean): JSONObject? {
+        val objects = result.getJSONArray("result")
+        for (i in 0 until objects.length()) {
+            val obj = objects.getJSONObject(i)
+            if (lambda(obj)) {
+                return obj
+            }
+        }
+        return null
+    }
+
+    private fun findByName(result: JSONObject, name: String): JSONObject? {
+        return findInResult(result) { it.getString("name") == name }
+    }
+
+    private fun findInGroup(engine: Delphix, groupName: String, name: String): JSONObject? {
+        val group = findByName(engine.group().list(), groupName) ?: return null
+        val groupRef = group.getString("reference")
+
+        return findInResult(engine.container().list()) {
+            it.getString("name") == name && it.getString("group") == groupRef
+        }
+    }
+
+    private fun getRepository(engine: Delphix): Repository? {
+        for (r in engine.repository().list()) {
+            if (r.name == "Titan") {
+                return r
+            }
+        }
+        return null
+    }
+
+    private fun getEnvUser(engine: Delphix, env: JSONObject): JSONObject? {
+        return findInResult(engine.environmentUser().list()) {
+            it.getString("environment") == env.getString("reference")
+        }
+    }
+
+    fun waitForJob(engine: Delphix, result: JSONObject) {
+        val actionResult: JSONObject = engine.action().read(result.getString("action")).getJSONObject("result")
+        if (actionResult.optString("state") == "COMPLETED") {
+            log.debug("action ${actionResult.getString("reference")} complete")
+            println(actionResult.getString("title"))
+        } else {
+            log.debug("waiting for job ${result.getString("job")}")
+            var job: JSONObject = engine.job().read(result.getString("job")).getJSONObject("result")
+            while (job.optString("jobState") == "RUNNING") {
+                Thread.sleep(5000)
+                job = engine.job().read(result.getString("job")).getJSONObject("result")
+            }
+
+            if (job.optString("jobState") != "COMPLETED") {
+                throw Exception("engine job ${job.getString("reference")} failed")
+            }
+            log.debug("engine job ${job.getString("reference")} complete")
+        }
+    }
+
+    fun repoExists(engine: Delphix, name: String): Boolean {
+        return findInGroup(engine, "repositories", name) != null
+    }
+
+    private fun listSnapshots(engine: Delphix, remote: Map<String, Any>): List<JSONObject> {
+        val name = remote["repository"] as String
+
+        if (!repoExists(engine, name)) {
+            throw Exception("no such repository '$name'")
+        }
+
+        val ret = ArrayList<JSONObject>()
+        val snapshots = engine.snapshot().list().getJSONArray("result")
+        for (i in 0 until snapshots.length()) {
+            val snapshot = snapshots.getJSONObject(i)
+            val properties = snapshot.optJSONObject("metadata")
+            if (properties != null && properties.has("repository") && properties.has("hash")) {
+                if (properties.getString("repository") == name && properties.getString("hash") != "") {
+                    ret.add(properties)
+                }
+            }
+        }
+
+        return ret
+    }
+
     override fun getCommit(remote: Map<String, Any>, parameters: Map<String, Any>, commitId: String): Map<String, Any>? {
-        throw NotImplementedError()
+        // This is horribly inefficient, but all we can do until we have a better API
+        val commits = listCommits(remote, parameters, emptyList())
+        return commits.find { it.first == commitId } ?.second
     }
 
     override fun listCommits(remote: Map<String, Any>, parameters: Map<String, Any>, tags: List<Pair<String, String?>>): List<Pair<String, Map<String, Any>>> {
-        throw NotImplementedError()
+        val engine = connect(remote, parameters)
+        val commits = listSnapshots(engine, remote).map {
+            it.getString("hash") to it.getJSONObject("metadata").toMap()
+        }
+        val filtered = commits.filter { util.matchTags(it.second, tags) }
+        return util.sortDescending(filtered)
     }
 
     override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {

--- a/server/src/main/kotlin/io/titandata/remote/delphix/server/DelphixRemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/delphix/server/DelphixRemoteServer.kt
@@ -113,7 +113,7 @@ class DelphixRemoteServer : RemoteServer {
         val name = remote["repository"] as String
 
         if (!repoExists(engine, name)) {
-            throw Exception("no such repository '$name'")
+            return emptyList()
         }
 
         val ret = ArrayList<JSONObject>()


### PR DESCRIPTION
## Proposed Changes

This adds interfaces for managing remote commits in the engine provider.

## Testing

`titan-server` endtoend tests